### PR TITLE
Dockerfile: fixed build error, multi-stage build, reduced image size from 369MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM golang:1.15-alpine3.12 AS build-env
-RUN apk add --no-cache git
-WORKDIR /go/src/app
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
 
 FROM alpine:3.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.15-alpine3.12 AS build-env
-
-RUN apk add --no-cache --upgrade git openssh-client ca-certificates
+RUN apk add --no-cache git
 WORKDIR /go/src/app
+RUN GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
 
-# Install
-RUN go get -u -v github.com/projectdiscovery/dnsx/cmd/dnsx
-
+FROM alpine:3.12
+COPY --from=build-env /go/bin/dnsx /usr/local/bin/dnsx
 ENTRYPOINT ["dnsx"]


### PR DESCRIPTION
Dockerfile: Nothing is glaringly bad here, there isn't much going on. 
Yet to begin with, I couldn't even get the image to build. The resulting errors:
```
../github.com/projectdiscovery/dnsx/internal/runner/banner.go:18:2: undefined: gologger.Printf
../github.com/projectdiscovery/dnsx/internal/runner/banner.go:19:2: undefined: gologger.Printf
../github.com/projectdiscovery/dnsx/internal/runner/banner.go:21:2: undefined: gologger.Labelf
../github.com/projectdiscovery/dnsx/internal/runner/banner.go:22:2: undefined: gologger.Labelf
../github.com/projectdiscovery/dnsx/internal/runner/options.go:74:3: undefined: gologger.Infof
../github.com/projectdiscovery/dnsx/internal/runner/options.go:85:3: undefined: gologger.Fatalf
../github.com/projectdiscovery/dnsx/internal/runner/options.go:93:3: undefined: gologger.MaxLevel
../github.com/projectdiscovery/dnsx/internal/runner/options.go:96:3: undefined: gologger.MaxLevel
../github.com/projectdiscovery/dnsx/internal/runner/runner.go:45:5: undefined: gologger.Fatalf
../github.com/projectdiscovery/dnsx/internal/runner/runner.go:260:4: undefined: gologger.Fatalf
../github.com/projectdiscovery/dnsx/internal/runner/runner.go:260:4: too many errors
```
I fixed that by including `GO111MODULE=on`, basically reversing commit #b302428, and omitting the `-u` flag.
After fixing that, the image builds successfully and is 369MB.. That's unnecessarily big compared to the 7.9M binary.

- LN1: Why did the dockerfile start as a mutli-stage build, but then stop there? It would be have smart to keep going with that idea, omit the source, export the binary, choose a smaller base and the resulting image would be much, much smaller.
- LN3: From my testing, `apk add --upgrade openssh-client ca-certificates git` appears to be extraneous in this particular build stage.
- LN4: `WORKDIR /go/src/app`, for what?
- LN7: `-u` is not needed because it will force update the module dependencies to their latest instead of using the version declarations in the source file, which i'm sure the author put there for a reason. Also `GO111MODULE=ON` seems to be be necessary for successful compilation. I'm unsure why, but feel free to test is yourself.

Here it is rewritten with my suggestions.  The resulting image is 13.9MB. Just alpine + dnsx, compare that to the original 369MB..

```
FROM golang:1.15-alpine3.12 AS build-env
RUN GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx

FROM alpine:3.12
COPY --from=build-env /go/bin/dnsx /usr/local/bin/dnsx
ENTRYPOINT ["dnsx"]
```