### PR TITLE
Optimize Dockerfile and implement CI/CD to DockerHub

### DIFF
--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,0 +1,36 @@
+name: ci-to-dockerhub
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/dnsx:latest
+          
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM golang:1.16.4-alpine3.12 AS build-env
+# Build image: golang:1.16.7-alpine3.14
+FROM golang@sha256:7e31a85c5b182e446c9e0e6fba57c522902f281a6a5a6cbd25afa17ac48a6b85 as build
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
 
-FROM alpine:latest
+# Release image: alpine:3.14.1
+FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+
 RUN apk add --no-cache bind-tools ca-certificates
-COPY --from=build-env /go/bin/dnsx /usr/local/bin/dnsx
+COPY --from=build /go/bin/dnsx /usr/local/bin/dnsx
+
+RUN adduser \
+    --gecos "" \
+    --disabled-password \
+    dnsx
+
+USER dnsx
+
 ENTRYPOINT ["dnsx"]


### PR DESCRIPTION
This PR fixes and modifies the Dockerfile in dnsx with the following considerations:

- Adds deterministic base images for reproducible builds.
- Added a least-privileged user in compliance with Docker security best practices.

We also have a workflow with a CICD pipeline to DockerHub. All you need to do is to add the DOCKER_HUB_USERNAME and DOCKER_HUB_ACCESS_TOKEN secrets to the repository and all pushes/merges to the master branch will automatically push an image to DockerHub.