### PR TITLE
build: bump to use latest go1.16

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,18 +5,15 @@ on:
   workflow_dispatch:
 
 
-jobs:  
+jobs:
   build:
     name: Test Builds
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
-
-      - name: Check out code
-        uses: actions/checkout@v2
+          go-version: 1.16
 
       - name: Test
         run: go test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.16.4-alpine3.12 AS build-env
-RUN GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
+FROM golang:1.16.7-alpine3.14 AS build-env
+RUN go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
 
-FROM alpine:latest
+FROM alpine:3.14
 RUN apk add --no-cache bind-tools ca-certificates
 COPY --from=build-env /go/bin/dnsx /usr/local/bin/dnsx
 ENTRYPOINT ["dnsx"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <a href="https://twitter.com/pdiscoveryio"><img src="https://img.shields.io/twitter/follow/pdiscoveryio.svg?logo=twitter"></a>
 <a href="https://discord.gg/projectdiscovery"><img src="https://img.shields.io/discord/695645237418131507.svg?logo=discord"></a>
 </p>
-      
+
 <p align="center">
   <a href="#features">Features</a> •
   <a href="#installation-instructions">Installation</a> •
@@ -90,10 +90,10 @@ This will display help for the tool. Here are all the switches it supports.
 # Installation Instructions
 
 
-dnsx requires **go1.14+** to install successfully. Run the following command to get the repo - 
+dnsx requires **go1.16+** to install successfully. Run the following command to get the repo -
 
 ```sh
-GO111MODULE=on go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
+go get -v github.com/projectdiscovery/dnsx/cmd/dnsx
 ```
 
 ### Running dnsx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/dnsx
 
-go 1.14
+go 1.16
 
 require (
 	github.com/golang/protobuf v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,6 @@ github.com/projectdiscovery/mapcidr v0.0.8 h1:16U05F2x3o/jSTsxSCY2hCuCs9xOSwVxjo
 github.com/projectdiscovery/mapcidr v0.0.8/go.mod h1:7CzdUdjuLVI0s33dQ33lWgjg3vPuLFw2rQzZ0RxkT00=
 github.com/projectdiscovery/reflectutil v0.0.0-20210804085554-4d90952bf92f h1:HR3R/nhELwLXufUlO1ZkKVqrZl4lN1cWFBdN8RcMuLo=
 github.com/projectdiscovery/reflectutil v0.0.0-20210804085554-4d90952bf92f/go.mod h1:3L0WfNIcVWXIDur8k+gKDLZLWY2F+rs0SQXtcn/3AYU=
-github.com/projectdiscovery/retryabledns v1.0.13-0.20210804172212-e02a826811fb h1:6dMOuJFvztHeQjKo2BP4T5HLMrzvR5aU1/zXkQqlmtI=
-github.com/projectdiscovery/retryabledns v1.0.13-0.20210804172212-e02a826811fb/go.mod h1:4sMC8HZyF01HXukRleSQYwz4870bwgb4+hTSXTMrkf4=
 github.com/projectdiscovery/retryabledns v1.0.13-0.20210806114851-086e157ea157 h1:bWH3ZRz0UTQNYgnWhfFCQs/7NbT88WmYRVwRSiT+b/c=
 github.com/projectdiscovery/retryabledns v1.0.13-0.20210806114851-086e157ea157/go.mod h1:4sMC8HZyF01HXukRleSQYwz4870bwgb4+hTSXTMrkf4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
go1.16 support apple silicon and use `go modules` by default.