### PR TITLE
Enabling support for TCP fallback on UDP truncation

### DIFF
--- a/libs/dnsx/dnsx.go
+++ b/libs/dnsx/dnsx.go
@@ -51,6 +51,7 @@ func New(options Options) (*DNSX, error) {
 	}
 
 	dnsClient := retryabledns.NewWithOptions(retryablednsOptions)
+	dnsClient.TCPFallback = true
 
 	return &DNSX{dnsClient: dnsClient, Options: &options}, nil
 }


### PR DESCRIPTION
This PR enables automatic support for TCP fallback in case the UDP requests is truncated