### PR TITLE
Support specified domain and dictionary to discover

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -22,7 +22,8 @@ type Options struct {
 	Resolvers         string
 	Hosts             string
 	Domain            string
-	WordDictFile      string
+	DomainsFile       string
+	WordListFile      string
 	Threads           int
 	RateLimit         int
 	Retries           int
@@ -75,8 +76,8 @@ func ParseOptions() *Options {
 
 	createGroup(flagSet, "input", "Input",
 		flagSet.StringVarP(&options.Hosts, "list", "l", "", "File input with list of sub(domains)/hosts"),
-		flagSet.StringVarP(&options.Domain, "domain", "d", "", "Domain or Host"),
-		flagSet.StringVarP(&options.WordDictFile, "word", "w", "", "File input with list of subdomain dict"),
+		flagSet.StringVarP(&options.Domain, "domain", "d", "", "Domain to find subdomains for"),
+		flagSet.StringVarP(&options.DomainsFile, "domains", "dL", "", "File containing list of domains to enumerate"),
 	)
 
 	createGroup(flagSet, "query", "Query",
@@ -121,6 +122,7 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.TraceMaxRecursion, "trace-max-recursion", math.MaxInt16, "Max recursion for dns trace"),
 		flagSet.IntVar(&options.FlushInterval, "flush-interval", 10, "Flush interval of output file"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "Resume"),
+		flagSet.StringVarP(&options.WordListFile, "words", "w", "", "File input with list of subdomain dict"),
 	)
 
 	createGroup(flagSet, "configs", "Configurations",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -28,7 +28,6 @@ type Options struct {
 	Retries           int
 	OutputFormat      string
 	OutputFile        string
-	Enum              bool
 	Raw               bool
 	Silent            bool
 	Verbose           bool
@@ -121,7 +120,6 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.TraceMaxRecursion, "trace-max-recursion", math.MaxInt16, "Max recursion for dns trace"),
 		flagSet.IntVar(&options.FlushInterval, "flush-interval", 10, "Flush interval of output file"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "Resume"),
-		flagSet.BoolVar(&options.Enum, "enum", false, "enum"),
 		flagSet.StringVarP(&options.WordList, "words", "w", "", "List of subdomains to bruteforce  (file)"),
 	)
 
@@ -161,10 +159,6 @@ func ParseOptions() *Options {
 func (options *Options) validateOptions() {
 	if options.Response && options.ResponseOnly {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
-	}
-
-	if options.WordList == "" && options.Enum {
-		gologger.Fatal().Msgf("please input wordlist file with -w flag")
 	}
 }
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -22,7 +22,7 @@ type Options struct {
 	Resolvers         string
 	Hosts             string
 	Domains           string
-	WordListFile      string
+	WordList          string
 	Threads           int
 	RateLimit         int
 	Retries           int
@@ -122,7 +122,7 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.FlushInterval, "flush-interval", 10, "Flush interval of output file"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "Resume"),
 		flagSet.BoolVar(&options.Enum, "enum", false, "enum"),
-		flagSet.StringVarP(&options.WordListFile, "words", "w", "", "List of subdomains to bruteforce  (file)"),
+		flagSet.StringVarP(&options.WordList, "words", "w", "", "List of subdomains to bruteforce  (file)"),
 	)
 
 	createGroup(flagSet, "configs", "Configurations",
@@ -163,7 +163,7 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
 	}
 
-	if options.WordListFile == "" && options.Enum {
+	if options.WordList == "" && options.Enum {
 		gologger.Fatal().Msgf("please input wordlist file with -w flag")
 	}
 }

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -162,6 +162,10 @@ func (options *Options) validateOptions() {
 	if options.Response && options.ResponseOnly {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
 	}
+
+	if (options.Domain != "" || options.DomainsFile != "") && options.Hosts != "" {
+		gologger.Fatal().Msgf("-l and -d/-dL can't be used at the same time")
+	}
 }
 
 // configureOutput configures the output on the screen

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -74,8 +74,9 @@ func ParseOptions() *Options {
 	flagSet.SetDescription(`dnsx is a fast and multi-purpose DNS toolkit allow to run multiple probes using retryabledns library.`)
 
 	createGroup(flagSet, "input", "Input",
-		flagSet.StringVarP(&options.Hosts, "list", "l", "", "File input with list of sub(domains)/hosts"),
-		flagSet.StringVarP(&options.Domains, "domains", "d", "", "List of domain (comma separated)"),
+		flagSet.StringVarP(&options.Hosts, "list", "l", "", "List of sub(domains)/hosts to resolve (file)"),
+		flagSet.StringVarP(&options.Domains, "domain", "d", "", "List of domain to bruteforce (file or comma separated)"),
+		flagSet.StringVarP(&options.WordList, "wordlist", "w", "", "List of words to bruteforce (file or comma separated)"),
 	)
 
 	createGroup(flagSet, "query", "Query",
@@ -120,7 +121,6 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.TraceMaxRecursion, "trace-max-recursion", math.MaxInt16, "Max recursion for dns trace"),
 		flagSet.IntVar(&options.FlushInterval, "flush-interval", 10, "Flush interval of output file"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "Resume"),
-		flagSet.StringVarP(&options.WordList, "words", "w", "", "List of subdomains to bruteforce  (file)"),
 	)
 
 	createGroup(flagSet, "configs", "Configurations",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -166,6 +166,10 @@ func (options *Options) validateOptions() {
 	if (options.Domain != "" || options.DomainsFile != "") && options.Hosts != "" {
 		gologger.Fatal().Msgf("-l and -d/-dL can't be used at the same time")
 	}
+
+	if (options.Domain != "" || options.DomainsFile != "") && options.WordListFile == "" {
+		gologger.Fatal().Msgf("-d/-dL must set wordlist(-w)")
+	}
 }
 
 // configureOutput configures the output on the screen

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -167,7 +167,7 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("-l and -d/-dL can't be used at the same time")
 	}
 
-	if (options.Domain != "" || options.DomainsFile != "") && options.WordListFile == "" {
+	if (options.Domain != "" || options.DomainsFile != "") && (options.WordListFile == "" && !fileutil.HasStdin()) {
 		gologger.Fatal().Msgf("-d/-dL must set wordlist(-w)")
 	}
 }

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	Retries           int
 	OutputFormat      string
 	OutputFile        string
+	Enum              bool
 	Raw               bool
 	Silent            bool
 	Verbose           bool
@@ -76,8 +77,6 @@ func ParseOptions() *Options {
 
 	createGroup(flagSet, "input", "Input",
 		flagSet.StringVarP(&options.Hosts, "list", "l", "", "File input with list of sub(domains)/hosts"),
-		flagSet.StringVarP(&options.Domain, "domain", "d", "", "Domain to find subdomains for"),
-		flagSet.StringVarP(&options.DomainsFile, "domains", "dL", "", "File containing list of domains to enumerate"),
 	)
 
 	createGroup(flagSet, "query", "Query",
@@ -122,6 +121,7 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.TraceMaxRecursion, "trace-max-recursion", math.MaxInt16, "Max recursion for dns trace"),
 		flagSet.IntVar(&options.FlushInterval, "flush-interval", 10, "Flush interval of output file"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "Resume"),
+		flagSet.BoolVar(&options.Enum, "enum", false, "emun"),
 		flagSet.StringVarP(&options.WordListFile, "words", "w", "", "File input with list of subdomain dict"),
 	)
 
@@ -163,12 +163,8 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
 	}
 
-	if (options.Domain != "" || options.DomainsFile != "") && options.Hosts != "" {
-		gologger.Fatal().Msgf("-l and -d/-dL can't be used at the same time")
-	}
-
-	if (options.Domain != "" || options.DomainsFile != "") && (options.WordListFile == "" && !fileutil.HasStdin()) {
-		gologger.Fatal().Msgf("-d/-dL must set wordlist(-w)")
+	if options.WordListFile == "" && options.Enum {
+		gologger.Fatal().Msgf("please input wordlist file with -w flag")
 	}
 }
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -21,8 +21,7 @@ const (
 type Options struct {
 	Resolvers         string
 	Hosts             string
-	Domain            string
-	DomainsFile       string
+	Domains           string
 	WordListFile      string
 	Threads           int
 	RateLimit         int
@@ -77,6 +76,7 @@ func ParseOptions() *Options {
 
 	createGroup(flagSet, "input", "Input",
 		flagSet.StringVarP(&options.Hosts, "list", "l", "", "File input with list of sub(domains)/hosts"),
+		flagSet.StringVarP(&options.Domains, "domains", "d", "", "List of domain (comma separated)"),
 	)
 
 	createGroup(flagSet, "query", "Query",
@@ -121,8 +121,8 @@ func ParseOptions() *Options {
 		flagSet.IntVar(&options.TraceMaxRecursion, "trace-max-recursion", math.MaxInt16, "Max recursion for dns trace"),
 		flagSet.IntVar(&options.FlushInterval, "flush-interval", 10, "Flush interval of output file"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "Resume"),
-		flagSet.BoolVar(&options.Enum, "enum", false, "emun"),
-		flagSet.StringVarP(&options.WordListFile, "words", "w", "", "File input with list of subdomain dict"),
+		flagSet.BoolVar(&options.Enum, "enum", false, "enum"),
+		flagSet.StringVarP(&options.WordListFile, "words", "w", "", "List of subdomains to bruteforce  (file)"),
 	)
 
 	createGroup(flagSet, "configs", "Configurations",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -21,6 +21,8 @@ const (
 type Options struct {
 	Resolvers         string
 	Hosts             string
+	Domain            string
+	WordDictFile      string
 	Threads           int
 	RateLimit         int
 	Retries           int
@@ -73,6 +75,8 @@ func ParseOptions() *Options {
 
 	createGroup(flagSet, "input", "Input",
 		flagSet.StringVarP(&options.Hosts, "list", "l", "", "File input with list of sub(domains)/hosts"),
+		flagSet.StringVarP(&options.Domain, "domain", "d", "", "Domain or Host"),
+		flagSet.StringVarP(&options.WordDictFile, "word", "w", "", "File input with list of subdomain dict"),
 	)
 
 	createGroup(flagSet, "query", "Query",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -195,7 +195,7 @@ func (r *Runner) prepareInput() error {
 	numHosts := 0
 	for sc.Scan() {
 		item := strings.TrimSpace(sc.Text())
-		var hosts []string
+		var hosts = []string{item}
 		if r.options.Enum {
 			var subdomain string
 			for _, prefix := range prefixs {
@@ -204,7 +204,6 @@ func (r *Runner) prepareInput() error {
 				hosts = append(hosts, subdomain)
 			}
 		} else {
-			hosts = []string{item}
 			if iputil.IsCIDR(item) {
 				hosts, _ = mapcidr.IPAddresses(item)
 			}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -168,6 +168,17 @@ func (r *Runner) prepareInput() error {
 			return err
 		}
 		defer f.Close()
+	} else if r.options.WordDictFile != "" {
+		if r.options.Domain != "" {
+			var err error
+			f, err = os.Open(r.options.WordDictFile)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+		} else {
+			return fmt.Errorf("domain not provided")
+		}
 	} else if (stat.Mode() & os.ModeCharDevice) == 0 {
 		f = os.Stdin
 	} else {
@@ -178,6 +189,9 @@ func (r *Runner) prepareInput() error {
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		item := strings.TrimSpace(sc.Text())
+		if r.options.Domain != "" {
+			item = item + "." + r.options.Domain
+		}
 		hosts := []string{item}
 		if iputil.IsCIDR(item) {
 			hosts, _ = mapcidr.IPAddresses(item)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -185,11 +185,15 @@ func (r *Runner) prepareInput() error {
 	//read wordlist file
 	var prefixs []string
 	if r.options.Enum {
-		content, err := ioutil.ReadFile(r.options.WordListFile)
-		if err != nil {
-			return err
+		if fileutil.FileExists(r.options.WordList) {
+			content, err := ioutil.ReadFile(r.options.WordList)
+			if err != nil {
+				gologger.Fatal().Msgf("%s\n", err)
+			}
+			prefixs = strings.Split(string(content), "\n")
+		} else {
+			prefixs = strings.Split(r.options.WordList, ",")
 		}
-		prefixs = strings.Split(string(content), "\n")
 	}
 
 	numHosts := 0

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -184,7 +184,7 @@ func (r *Runner) prepareInput() error {
 
 	//read wordlist file
 	var prefixs []string
-	if r.options.Enum {
+	if r.options.WordList != "" {
 		if fileutil.FileExists(r.options.WordList) {
 			content, err := ioutil.ReadFile(r.options.WordList)
 			if err != nil {
@@ -200,7 +200,7 @@ func (r *Runner) prepareInput() error {
 	for sc.Scan() {
 		item := strings.TrimSpace(sc.Text())
 		var hosts = []string{item}
-		if r.options.Enum {
+		if r.options.WordList != "" {
 			var subdomain string
 			for _, prefix := range prefixs {
 				// domains Cartesian product with wordlist


### PR DESCRIPTION
example: 
`dnsx -w word.txt -d shein.com -resp -a`
or
`cat word.txt | dnsx -d shein.com -resp -a`

word.txt:
```
www
oa
m
```

result:
```
                projectdiscovery.io
Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
m.shein.com [23.50.233.158]
m.shein.com [23.50.233.166]
m.shein.com [23.50.233.157]
m.shein.com [23.50.233.160]
m.shein.com [23.50.233.152]
m.shein.com [23.50.233.165]
m.shein.com [23.50.233.176]
m.shein.com [23.50.233.150]
m.shein.com [23.50.233.167]
www.shein.com [23.50.233.231]
www.shein.com [23.50.233.222]
www.shein.com [23.50.233.206]
www.shein.com [23.50.233.208]
www.shein.com [23.50.233.207]
www.shein.com [23.50.233.216]
www.shein.com [23.50.233.143]
www.shein.com [23.50.233.224]
www.shein.com [23.50.233.213]
```


