### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.17.8-alpine3.14 AS build-env
+RUN apk add --no-cache build-base
 RUN go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
 
 FROM alpine:3.15.0


### PR DESCRIPTION
Added build-base so build succeeds. Without gcc building from the current Dockerfile throws the following error.

```
#10 55.48 golang.org/x/exp/rand
#10 55.61 github.com/cockroachdb/pebble/internal/rawalloc
#10 55.65 github.com/cockroachdb/pebble/internal/manual
#10 55.66 github.com/projectdiscovery/gologger/formatter
#10 55.67 # github.com/cockroachdb/pebble/internal/manual
#10 55.67 cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
#10 55.67 github.com/cockroachdb/pebble/internal/bytealloc
#10 55.67 github.com/cockroachdb/pebble/internal/humanize
#10 55.73 github.com/cockroachdb/pebble/internal/crc
#10 55.74 github.com/projectdiscovery/gologger
#10 55.75 github.com/DataDog/zstd
#10 55.78 github.com/cespare/xxhash/v2
#10 55.78 # github.com/DataDog/zstd
#10 55.78 cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
#10 55.78 github.com/cockroachdb/pebble/internal/intern
```