### PR TITLE
add stdin domain support with wordlist

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -189,7 +189,7 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("list(l) flag can not be used domain(d) or wordlist(w) flag")
 	}
 
-	if wordListPresent && !domainsPresent {
+	if wordListPresent && !domainsPresent && !fileutil.HasStdin() {
 		gologger.Fatal().Msg("missing domain(d) flag required with wordlist(w) input")
 	}
 	if domainsPresent && !wordListPresent {


### PR DESCRIPTION
example:
```console
$ echo projectdiscovery.io | go run cmd/dnsx/dnsx.go -w www,nuclei,blog

      _             __  __
   __| | _ __   ___ \ \/ /
  / _' || '_ \ / __| \  / 
 | (_| || | | |\__ \ /  \ 
  \__,_||_| |_||___//_/\_\ v1.1.1

                projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
nuclei.projectdiscovery.io
www.projectdiscovery.io
blog.projectdiscovery.io
```