### PR TITLE
Adding support for json output with wildcard filtering

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -141,7 +141,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("configs", "Configurations",
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
-		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored)"),
+		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
 	)
 
 	_ = flagSet.Parse()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -489,12 +489,12 @@ func (r *Runner) run() error {
 				if host == r.options.WildcardDomain {
 					if _, ok := seen[host]; !ok {
 						seen[host] = struct{}{}
-						r.outputchan <- host
+						r.lookupAndOutput(host)
 					}
 				} else if _, ok := r.wildcards[host]; !ok {
 					if _, ok := seen[host]; !ok {
 						seen[host] = struct{}{}
-						r.outputchan <- host
+						r.lookupAndOutput(host)
 					}
 				} else {
 					if _, ok := seenRemovedSubdomains[host]; !ok {
@@ -510,6 +510,27 @@ func (r *Runner) run() error {
 		gologger.Print().Msgf("%d wildcard subdomains removed\n", numRemovedSubdomains)
 	}
 
+	return nil
+}
+
+func (r *Runner) lookupAndOutput(host string) error {
+	if r.options.JSON {
+		if data, ok := r.hm.Get(host); ok {
+			var dnsData retryabledns.DNSData
+			err := dnsData.Unmarshal(data)
+			if err != nil {
+				return err
+			}
+			dnsDataJson, err := dnsData.JSON()
+			if err != nil {
+				return err
+			}
+			r.outputchan <- dnsDataJson
+			return err
+		}
+	}
+
+	r.outputchan <- host
 	return nil
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -489,12 +489,12 @@ func (r *Runner) run() error {
 				if host == r.options.WildcardDomain {
 					if _, ok := seen[host]; !ok {
 						seen[host] = struct{}{}
-						r.lookupAndOutput(host)
+						_ = r.lookupAndOutput(host)
 					}
 				} else if _, ok := r.wildcards[host]; !ok {
 					if _, ok := seen[host]; !ok {
 						seen[host] = struct{}{}
-						r.lookupAndOutput(host)
+						_ = r.lookupAndOutput(host)
 					}
 				} else {
 					if _, ok := seenRemovedSubdomains[host]; !ok {


### PR DESCRIPTION
## Description
Closes #276 

## Example
```console
$ echo www.hackerone.com | go run . -silent -a -cname -ns -output dnsx.json -wd hackerone.com -wt 10 -verbose -json
{"host":"www.hackerone.com","resolver":["1.0.0.1:53"],"a":["104.16.100.52","104.16.99.52"], ...}
```