### PR TITLE
Fix PDCP branding

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -177,7 +177,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",
-		flagSet.DynamicVar(&options.PdcpAuth, "auth", "true", "configure projectdiscovery cloud (pdcp) api key"),
+		flagSet.DynamicVar(&options.PdcpAuth, "auth", "true", "configure ProjectDiscovery Cloud Platform (PDCP) api key"),
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),


### PR DESCRIPTION
This corrects the branding for ProjectDiscovery Cloud platform.

@ehsandeep @RamanaReddy0M the other "problem" is that the `"true"` default causes an interesting output in help: 
![CleanShot 2024-03-08 at 12 35 55](https://github.com/projectdiscovery/dnsx/assets/6044920/4e9fb497-dc43-4597-bc5f-e9fe0d85cb65)

I wasn't sure how to fix that but this PR at least corrects the branding of PDCP