### PR TITLE
Remove default `noerror` filter

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -366,12 +366,6 @@ func (options *Options) configureRcodes() error {
 	}
 
 	options.hasRCodes = options.RCode != ""
-
-	// Set rcode to 0 if none was specified
-	if len(options.rcodes) == 0 {
-		options.rcodes[0] = struct{}{}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
- closes #630 

TEST:
```console
✗ echo sip.contractors.contractors.tesla.com | ./dnsx -trace -j | jq
```