### PR TITLE
fix no color option

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -6,9 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/projectdiscovery/goconfig"
 	"github.com/projectdiscovery/goflags"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/gologger/formatter"
 	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/utils/auth/pdcp"
 	"github.com/projectdiscovery/utils/env"
@@ -209,9 +211,6 @@ func ParseOptions() *Options {
 
 	options.configureQueryOptions()
 
-	// Read the inputs and configure the logging
-	options.configureOutput()
-
 	err := options.configureRcodes()
 	if err != nil {
 		gologger.Fatal().Msgf("%s\n", err)
@@ -236,6 +235,7 @@ func ParseOptions() *Options {
 		}
 	}
 
+	options.configureOutput()
 	showBanner()
 
 	if options.Version {
@@ -319,6 +319,10 @@ func (options *Options) configureOutput() {
 	// If the user desires verbose output, show verbose output
 	if options.Verbose {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelVerbose)
+	}
+	if options.NoColor {
+		updateutils.Aurora = aurora.NewAurora(false)
+		gologger.DefaultLogger.SetFormatter(formatter.NewCLI(true))
 	}
 	if options.Silent {
 		gologger.DefaultLogger.SetMaxLevel(levels.LevelSilent)


### PR DESCRIPTION
closes https://github.com/projectdiscovery/dnsx/issues/877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for colorless output across the CLI and logs, ideal for CI environments and plain-text piping.
* **Refactor**
  * Adjusted startup sequence to apply output settings just before the banner is shown, ensuring consistent formatting after authentication and resume steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->