### PR TITLE
fix: display actual CNAME target in -cname output

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -847,8 +847,13 @@ func (r *Runner) outputRecordType(domain string, items interface{}, queryType, c
 		} else if r.options.Response {
 			r.outputchan <- fmt.Sprintf("%s [%s] [%s] %s", domain, r.aurora.Magenta(queryType), r.aurora.Green(item).String(), details)
 		} else {
-			// just prints out the domain if it has a record type and exit
-			r.outputchan <- fmt.Sprintf("%s%s", domain, details)
+			// In silent mode, previously only the domain name was printed.
+			// For CNAME records, we should also print the resolved target instead of just the domain.
+			if queryType == "CNAME" {
+				r.outputchan <- fmt.Sprintf("%s -> %s%s", domain, item, details)
+			} else {
+				r.outputchan <- fmt.Sprintf("%s%s", domain, details)
+			}
 			break
 		}
 	}


### PR DESCRIPTION
Fixes #905 

### Problem
The `-cname` flag only printed the input domain instead of the actual CNAME record target.  
Example:

```bash
$ echo jfkt.github.shopify.com | dnsx -silent -cname
jfkt.github.shopify.com
````

This was inconsistent with the expected behavior (e.g., `dig cname`), making it impossible to retrieve the true CNAME target with `dnsx`.

### Root Cause

In `outputRecordType()`, silent mode handling stopped after printing only the domain name.
CNAME record values (`dnsData.CNAME`) were discarded in this branch.

### Changes

* Updated `outputRecordType` logic:

  * For `CNAME`, print both the queried domain and the resolved target.
  * Example format: `domain -> target`
* Added inline comment for clarity.

### Result

**Before:**

```bash
$ echo jfkt.github.shopify.com | dnsx -silent -cname
jfkt.github.shopify.com

$ echo eu2.deployment.api.varonis.io | dnsx -silent -cname
eu2.deployment.api.varonis.io
```

**After:**

```bash
$ echo jfkt.github.shopify.com | ./dnsx -silent -cname
jfkt.github.shopify.com -> github.com.

$ echo eu2.deployment.api.varonis.io | ./dnsx -silent -cname
eu2.deployment.api.varonis.io -> eastus2-prd-distributed-deployment-ep.azureedge.net.
```
