### PR TITLE
feat: add auto-wildcard detection flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/projectdiscovery/utils v0.7.3
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.47.0
 )
 
 require (
@@ -120,7 +121,6 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/rs/xid"
+)
+
+// AutoWildcardDetector handles automatic wildcard detection across multiple domains
+type AutoWildcardDetector struct {
+	dnsx           *dnsx.DNSX
+	testCount      int
+	mutex          sync.RWMutex
+	wildcardRoots  map[string]map[string]struct{} // root domain -> set of wildcard IPs
+	testedDomains  map[string]struct{}            // domains we've already tested for wildcards
+	filteredCount  int                            // count of filtered wildcard subdomains
+}
+
+// NewAutoWildcardDetector creates a new auto wildcard detector
+func NewAutoWildcardDetector(dnsxClient *dnsx.DNSX, testCount int) *AutoWildcardDetector {
+	if testCount < 1 {
+		testCount = 3
+	}
+	return &AutoWildcardDetector{
+		dnsx:          dnsxClient,
+		testCount:     testCount,
+		wildcardRoots: make(map[string]map[string]struct{}),
+		testedDomains: make(map[string]struct{}),
+	}
+}
+
+// DetectAndFilter checks if a host is a wildcard subdomain
+// Returns true if the host should be filtered (is wildcard), false otherwise
+func (d *AutoWildcardDetector) DetectAndFilter(host string, hostIPs []string) bool {
+	if len(hostIPs) == 0 {
+		return false
+	}
+
+	// Extract parent domains to test for wildcards
+	parents := getParentDomains(host)
+	if len(parents) == 0 {
+		return false
+	}
+
+	// Ensure wildcard detection is done for all parent levels
+	for _, parent := range parents {
+		d.ensureWildcardTested(parent)
+	}
+
+	// Check if any of the host's IPs match known wildcard IPs
+	return d.isWildcardMatch(host, hostIPs)
+}
+
+// ensureWildcardTested tests a domain for wildcards if not already tested
+func (d *AutoWildcardDetector) ensureWildcardTested(parent string) {
+	d.mutex.RLock()
+	_, tested := d.testedDomains[parent]
+	d.mutex.RUnlock()
+
+	if tested {
+		return
+	}
+
+	// Mark as tested before actual test to prevent concurrent duplicate tests
+	d.mutex.Lock()
+	// Double-check after acquiring write lock
+	if _, tested := d.testedDomains[parent]; tested {
+		d.mutex.Unlock()
+		return
+	}
+	d.testedDomains[parent] = struct{}{}
+	d.mutex.Unlock()
+
+	// Test for wildcard by querying random subdomains
+	wildcardIPs := d.testWildcard(parent)
+
+	if len(wildcardIPs) > 0 {
+		d.mutex.Lock()
+		d.wildcardRoots[parent] = wildcardIPs
+		d.mutex.Unlock()
+	}
+}
+
+// testWildcard tests if a domain has wildcard DNS by querying random subdomains
+func (d *AutoWildcardDetector) testWildcard(parent string) map[string]struct{} {
+	wildcardIPs := make(map[string]struct{})
+	ipCounts := make(map[string]int)
+
+	// Query multiple random subdomains
+	for i := 0; i < d.testCount; i++ {
+		randomHost := xid.New().String() + "." + parent
+		result, err := d.dnsx.QueryOne(randomHost)
+		if err != nil || result == nil {
+			continue
+		}
+
+		for _, ip := range result.A {
+			ipCounts[ip]++
+		}
+	}
+
+	// An IP is considered a wildcard if it appears in at least one random subdomain query
+	// (if a random subdomain resolves, it indicates wildcard)
+	for ip, count := range ipCounts {
+		if count >= 1 {
+			wildcardIPs[ip] = struct{}{}
+		}
+	}
+
+	return wildcardIPs
+}
+
+// isWildcardMatch checks if any of the host's IPs match wildcard patterns
+func (d *AutoWildcardDetector) isWildcardMatch(host string, hostIPs []string) bool {
+	parents := getParentDomains(host)
+
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+
+	for _, parent := range parents {
+		if wildcardIPs, ok := d.wildcardRoots[parent]; ok {
+			for _, ip := range hostIPs {
+				if _, isWildcard := wildcardIPs[ip]; isWildcard {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// GetWildcardRoots returns all detected wildcard root domains
+func (d *AutoWildcardDetector) GetWildcardRoots() []string {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+
+	roots := make([]string, 0, len(d.wildcardRoots))
+	for root := range d.wildcardRoots {
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+// GetWildcardRootCount returns the number of wildcard roots detected
+func (d *AutoWildcardDetector) GetWildcardRootCount() int {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return len(d.wildcardRoots)
+}
+
+// IncrementFilteredCount increments the count of filtered wildcard subdomains
+func (d *AutoWildcardDetector) IncrementFilteredCount() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.filteredCount++
+}
+
+// GetFilteredCount returns the count of filtered wildcard subdomains
+func (d *AutoWildcardDetector) GetFilteredCount() int {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.filteredCount
+}
+
+// getParentDomains extracts all parent domain levels from a hostname
+// e.g., "sub.example.com" returns ["example.com"]
+// e.g., "a.b.example.com" returns ["b.example.com", "example.com"]
+func getParentDomains(host string) []string {
+	parts := strings.Split(host, ".")
+	if len(parts) <= 2 {
+		return nil // Already at apex or TLD
+	}
+
+	var parents []string
+	// Start from the immediate parent and go up
+	for i := 1; i < len(parts)-1; i++ {
+		parent := strings.Join(parts[i:], ".")
+		// Skip if it looks like a TLD (only 2 parts remaining)
+		if strings.Count(parent, ".") >= 1 {
+			parents = append(parents, parent)
+		}
+	}
+
+	return parents
+}

--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -16,6 +16,7 @@ type AutoWildcardDetector struct {
 	mutex          sync.RWMutex
 	wildcardRoots  map[string]map[string]struct{} // root domain -> set of wildcard IPs
 	testedDomains  map[string]struct{}            // domains we've already tested for wildcards
+	inFlight       map[string]chan struct{}       // domains currently being tested (for concurrent waiters)
 	filteredCount  int                            // count of filtered wildcard subdomains
 }
 
@@ -29,6 +30,7 @@ func NewAutoWildcardDetector(dnsxClient *dnsx.DNSX, testCount int) *AutoWildcard
 		testCount:     testCount,
 		wildcardRoots: make(map[string]map[string]struct{}),
 		testedDomains: make(map[string]struct{}),
+		inFlight:      make(map[string]chan struct{}),
 	}
 }
 
@@ -56,37 +58,47 @@ func (d *AutoWildcardDetector) DetectAndFilter(host string, hostIPs []string) bo
 
 // ensureWildcardTested tests a domain for wildcards if not already tested
 func (d *AutoWildcardDetector) ensureWildcardTested(parent string) {
-	d.mutex.RLock()
-	_, tested := d.testedDomains[parent]
-	d.mutex.RUnlock()
-
-	if tested {
-		return
-	}
-
-	// Mark as tested before actual test to prevent concurrent duplicate tests
 	d.mutex.Lock()
-	// Double-check after acquiring write lock
+
+	// Check if already tested (complete)
 	if _, tested := d.testedDomains[parent]; tested {
 		d.mutex.Unlock()
 		return
 	}
-	d.testedDomains[parent] = struct{}{}
+
+	// Check if another goroutine is currently testing this domain
+	if waitCh, inFlight := d.inFlight[parent]; inFlight {
+		d.mutex.Unlock()
+		// Wait for the in-flight test to complete
+		<-waitCh
+		return
+	}
+
+	// We'll be the one to test - create a channel for others to wait on
+	doneCh := make(chan struct{})
+	d.inFlight[parent] = doneCh
 	d.mutex.Unlock()
 
-	// Test for wildcard by querying random subdomains
+	// Test for wildcard by querying random subdomains (outside lock)
 	wildcardIPs := d.testWildcard(parent)
 
+	// Re-acquire lock to update state
+	d.mutex.Lock()
+	d.testedDomains[parent] = struct{}{}
 	if len(wildcardIPs) > 0 {
-		d.mutex.Lock()
 		d.wildcardRoots[parent] = wildcardIPs
-		d.mutex.Unlock()
 	}
+	delete(d.inFlight, parent)
+	d.mutex.Unlock()
+
+	// Signal waiting goroutines that testing is complete
+	close(doneCh)
 }
 
 // testWildcard tests if a domain has wildcard DNS by querying random subdomains
+// Returns IPs only if they are CONSISTENT across multiple probe responses
 func (d *AutoWildcardDetector) testWildcard(parent string) map[string]struct{} {
-	wildcardIPs := make(map[string]struct{})
+	var probeSets []map[string]struct{}
 
 	// Query multiple random subdomains
 	for i := 0; i < d.testCount; i++ {
@@ -96,18 +108,47 @@ func (d *AutoWildcardDetector) testWildcard(parent string) map[string]struct{} {
 			continue
 		}
 
-		// Add A record IPs directly to wildcardIPs
+		// Collect IPs from this probe
+		probeIPs := make(map[string]struct{})
 		for _, ip := range result.A {
-			wildcardIPs[ip] = struct{}{}
+			probeIPs[ip] = struct{}{}
+		}
+		for _, ip := range result.AAAA {
+			probeIPs[ip] = struct{}{}
 		}
 
-		// Also add AAAA record IPs for IPv6 wildcard detection
-		for _, ip := range result.AAAA {
-			wildcardIPs[ip] = struct{}{}
+		// Only track probes that returned IPs
+		if len(probeIPs) > 0 {
+			probeSets = append(probeSets, probeIPs)
+		}
+	}
+
+	// Require at least 2 successful probes to declare wildcard
+	if len(probeSets) < 2 {
+		return nil
+	}
+
+	// Find intersection of all probe results (consistent IPs across all probes)
+	wildcardIPs := probeSets[0]
+	for i := 1; i < len(probeSets); i++ {
+		wildcardIPs = intersectIPSets(wildcardIPs, probeSets[i])
+		if len(wildcardIPs) == 0 {
+			return nil // No consistent IPs across probes
 		}
 	}
 
 	return wildcardIPs
+}
+
+// intersectIPSets returns the intersection of two IP sets
+func intersectIPSets(a, b map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{})
+	for ip := range a {
+		if _, ok := b[ip]; ok {
+			result[ip] = struct{}{}
+		}
+	}
+	return result
 }
 
 // isWildcardMatch checks if any of the host's IPs match wildcard patterns

--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/rs/xid"
+	"golang.org/x/net/publicsuffix"
 )
 
 // AutoWildcardDetector handles automatic wildcard detection across multiple domains
@@ -86,7 +87,6 @@ func (d *AutoWildcardDetector) ensureWildcardTested(parent string) {
 // testWildcard tests if a domain has wildcard DNS by querying random subdomains
 func (d *AutoWildcardDetector) testWildcard(parent string) map[string]struct{} {
 	wildcardIPs := make(map[string]struct{})
-	ipCounts := make(map[string]int)
 
 	// Query multiple random subdomains
 	for i := 0; i < d.testCount; i++ {
@@ -96,15 +96,13 @@ func (d *AutoWildcardDetector) testWildcard(parent string) map[string]struct{} {
 			continue
 		}
 
+		// Add A record IPs directly to wildcardIPs
 		for _, ip := range result.A {
-			ipCounts[ip]++
+			wildcardIPs[ip] = struct{}{}
 		}
-	}
 
-	// An IP is considered a wildcard if it appears in at least one random subdomain query
-	// (if a random subdomain resolves, it indicates wildcard)
-	for ip, count := range ipCounts {
-		if count >= 1 {
+		// Also add AAAA record IPs for IPv6 wildcard detection
+		for _, ip := range result.AAAA {
 			wildcardIPs[ip] = struct{}{}
 		}
 	}
@@ -166,21 +164,30 @@ func (d *AutoWildcardDetector) GetFilteredCount() int {
 }
 
 // getParentDomains extracts all parent domain levels from a hostname
+// stopping at the registrable domain boundary (eTLD+1)
 // e.g., "sub.example.com" returns ["example.com"]
 // e.g., "a.b.example.com" returns ["b.example.com", "example.com"]
+// e.g., "sub.example.co.uk" returns ["example.co.uk"] (not "co.uk")
 func getParentDomains(host string) []string {
 	parts := strings.Split(host, ".")
 	if len(parts) <= 2 {
 		return nil // Already at apex or TLD
 	}
 
+	// Get the registrable domain (eTLD+1) to know where to stop
+	registrableDomain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err != nil {
+		return nil // Cannot determine registrable domain
+	}
+
 	var parents []string
-	// Start from the immediate parent and go up
-	for i := 1; i < len(parts)-1; i++ {
+	// Start from the immediate parent and go up to (and including) the registrable domain
+	for i := 1; i < len(parts); i++ {
 		parent := strings.Join(parts[i:], ".")
-		// Skip if it looks like a TLD (only 2 parts remaining)
-		if strings.Count(parent, ".") >= 1 {
-			parents = append(parents, parent)
+		parents = append(parents, parent)
+		// Stop when we reach the registrable domain
+		if parent == registrableDomain {
+			break
 		}
 	}
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,6 +59,8 @@ type Options struct {
 	TraceMaxRecursion     int
 	WildcardThreshold     int
 	WildcardDomain        string
+	AutoWildcard          bool
+	AutoWildcardTestCount int
 	ShowStatistics        bool
 	rcodes                map[int]struct{}
 	RCode                 string
@@ -189,6 +191,8 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatic wildcard detection and filtering across all domains"),
+		flagSet.IntVar(&options.AutoWildcardTestCount, "auto-wildcard-tests", 3, "number of random subdomain tests for auto wildcard detection"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "proxy to use (eg socks5://127.0.0.1:8080)"),
 	)
 
@@ -307,9 +311,16 @@ func (options *Options) validateOptions() {
 		if options.WildcardDomain != "" {
 			gologger.Fatal().Msgf("wildcard not supported in stream mode")
 		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
+		}
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")
 		}
+	}
+
+	if options.AutoWildcard && options.WildcardDomain != "" {
+		gologger.Fatal().Msgf("auto-wildcard and wildcard-domain flags cannot be used together")
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,22 +32,23 @@ import (
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
-	options             *Options
-	dnsx                *dnsx.DNSX
-	wgoutputworker      *sync.WaitGroup
-	wgresolveworkers    *sync.WaitGroup
-	wgwildcardworker    *sync.WaitGroup
-	workerchan          chan string
-	outputchan          chan string
-	wildcardworkerchan  chan string
-	wildcards           *mapsutil.SyncLockMap[string, struct{}]
-	wildcardscache      map[string][]string
-	wildcardscachemutex sync.Mutex
-	limiter             *ratelimit.Limiter
-	hm                  *hybrid.HybridMap
-	stats               clistats.StatisticsClient
-	tmpStdinFile        string
-	aurora              aurora.Aurora
+	options              *Options
+	dnsx                 *dnsx.DNSX
+	wgoutputworker       *sync.WaitGroup
+	wgresolveworkers     *sync.WaitGroup
+	wgwildcardworker     *sync.WaitGroup
+	workerchan           chan string
+	outputchan           chan string
+	wildcardworkerchan   chan string
+	wildcards            *mapsutil.SyncLockMap[string, struct{}]
+	wildcardscache       map[string][]string
+	wildcardscachemutex  sync.Mutex
+	limiter              *ratelimit.Limiter
+	hm                   *hybrid.HybridMap
+	stats                clistats.StatisticsClient
+	tmpStdinFile         string
+	aurora               aurora.Aurora
+	autoWildcardDetector *AutoWildcardDetector
 }
 
 func New(options *Options) (*Runner, error) {
@@ -163,6 +164,11 @@ func New(options *Options) (*Runner, error) {
 		hm:                 hm,
 		stats:              stats,
 		aurora:             aurora.NewAurora(!options.NoColor),
+	}
+
+	// Initialize auto wildcard detector if enabled
+	if options.AutoWildcard {
+		r.autoWildcardDetector = NewAutoWildcardDetector(dnsX, options.AutoWildcardTestCount)
 	}
 
 	return &r, nil
@@ -548,6 +554,15 @@ func (r *Runner) run() error {
 		gologger.Print().Msgf("%d wildcard subdomains removed\n", numRemovedSubdomains)
 	}
 
+	// Print auto wildcard summary
+	if r.options.AutoWildcard && r.autoWildcardDetector != nil {
+		filteredCount := r.autoWildcardDetector.GetFilteredCount()
+		rootCount := r.autoWildcardDetector.GetWildcardRootCount()
+		if filteredCount > 0 || rootCount > 0 {
+			gologger.Print().Msgf("Auto wildcard detection: %d wildcard roots found, %d subdomains filtered\n", rootCount, filteredCount)
+		}
+	}
+
 	return nil
 }
 
@@ -736,6 +751,15 @@ func (r *Runner) worker() {
 				gologger.Debug().Msgf("Failed to store DNS data for %s: %v\n", domain, err)
 			}
 			continue
+		}
+
+		// auto wildcard detection and filtering
+		if r.options.AutoWildcard && r.autoWildcardDetector != nil {
+			if r.autoWildcardDetector.DetectAndFilter(domain, dnsData.A) {
+				r.autoWildcardDetector.IncrementFilteredCount()
+				gologger.Debug().Msgf("Filtered wildcard subdomain: %s\n", domain)
+				continue
+			}
 		}
 
 		// if response type filter is set, we don't want to ignore them


### PR DESCRIPTION
/claim #924

## Summary
Implements automatic wildcard detection similar to PureDNS, as requested in #924.

## New Flags
- `--auto-wildcard` (`-aw`): Enable automatic wildcard detection and filtering
- `--auto-wildcard-tests`: Number of random subdomain tests (default 3)

## How It Works
1. For each domain being resolved, extracts parent domains
2. Tests parent domains with random subdomains (using xid for randomness)  
3. If random subdomains resolve to the same IPs, marks the domain as wildcard
4. Filters out any resolved subdomains matching wildcard IPs

## Usage
```bash
# Enable auto-wildcard detection
echo "subdomain.example.com" | dnsx -a --auto-wildcard

# Adjust number of test queries (default 3)
cat subdomains.txt | dnsx -a -aw --auto-wildcard-tests 5
```

## Implementation Details
- Thread-safe implementation with proper mutex handling
- Caches wildcard detection results to avoid redundant queries
- Prints summary at end: number of wildcard roots found and subdomains filtered
- Debug logging available with `-debug` flag

## Testing
Tested with various wildcard domains and verified:
- Random subdomains are properly generated
- Wildcard IPs are correctly identified
- Matching subdomains are filtered from output

---
Closes #924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic wildcard DNS detection: detects and filters wildcard subdomains during scans with configurable test count.
  * New CLI flags: --auto-wildcard to enable detection and --auto-wildcard-tests to set test count.
  * Summary reporting: shows detected wildcard roots and filtered subdomain count at completion.

* **Notes**
  * Disabled in stream mode and incompatible with the wildcard-domain option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->