### PR TITLE
feat: add auto-wildcard detection flag (-aw)

### DIFF
--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -1,0 +1,169 @@
+package runner
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/rs/xid"
+	"golang.org/x/net/publicsuffix"
+)
+
+// AutoWildcardDetector provides automatic detection and filtering of wildcard DNS records.
+// It probes random subdomains to identify wildcard patterns and caches results per base domain.
+// Thread-safe for concurrent use across multiple workers.
+type AutoWildcardDetector struct {
+	runner    *Runner
+	cache     map[string][]string // domain -> wildcard IPs
+	cacheLock sync.RWMutex
+	threshold int
+}
+
+// NewAutoWildcardDetector creates a new AutoWildcardDetector instance.
+// The threshold parameter controls how many random subdomain probes are made (default 5).
+// Higher values increase accuracy but also increase DNS query count.
+func NewAutoWildcardDetector(runner *Runner, threshold int) *AutoWildcardDetector {
+	if threshold <= 0 {
+		threshold = 5 // default threshold
+	}
+	return &AutoWildcardDetector{
+		runner:    runner,
+		cache:     make(map[string][]string),
+		threshold: threshold,
+	}
+}
+
+// GetBaseDomain extracts the base domain (eTLD+1) from a hostname.
+// It handles both regular hostnames and FQDNs with trailing dots.
+// For example, "www.google.com" and "www.google.com." both return "google.com".
+func (a *AutoWildcardDetector) GetBaseDomain(host string) string {
+	// Remove any leading and trailing dots (for FQDNs)
+	host = strings.TrimPrefix(host, ".")
+	host = strings.TrimSuffix(host, ".")
+
+	// Try to get the eTLD+1 (effective top-level domain plus one)
+	baseDomain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err != nil {
+		// Fallback: try to extract last two parts
+		parts := strings.Split(host, ".")
+		if len(parts) >= 2 {
+			return strings.Join(parts[len(parts)-2:], ".")
+		}
+		return host
+	}
+	return baseDomain
+}
+
+// DetectWildcard probes random subdomains of the given base domain to detect wildcard DNS.
+// It returns a slice of IPs that appear in the majority of probe responses (indicating wildcards).
+// Results are cached for efficiency on subsequent calls with the same base domain.
+func (a *AutoWildcardDetector) DetectWildcard(baseDomain string) []string {
+	a.cacheLock.RLock()
+	if ips, ok := a.cache[baseDomain]; ok {
+		a.cacheLock.RUnlock()
+		return ips
+	}
+	a.cacheLock.RUnlock()
+
+	// Guard against nil runner or dnsx to prevent panics in tests or future reuse
+	if a.runner == nil || a.runner.dnsx == nil {
+		return nil
+	}
+
+	// Generate random subdomains and query them
+	wildcardIPs := make(map[string]int)
+	successfulProbes := 0
+
+	for i := 0; i < a.threshold; i++ {
+		// Respect rate limits if limiter is configured
+		if a.runner != nil && a.runner.limiter != nil {
+			a.runner.limiter.Take()
+		}
+
+		randomSub := xid.New().String() + "." + baseDomain
+		result, err := a.runner.dnsx.QueryOne(randomSub)
+		if err != nil || result == nil {
+			continue
+		}
+
+		successfulProbes++
+
+		// Count occurrences of each IP (both A and AAAA records)
+		for _, ip := range result.A {
+			wildcardIPs[ip]++
+		}
+		for _, ip := range result.AAAA {
+			wildcardIPs[ip]++
+		}
+	}
+
+	// If no successful probes, don't cache and return empty
+	if successfulProbes == 0 {
+		return nil
+	}
+
+	// IPs that appear in the majority of successful probes are wildcard IPs
+	var wildcards []string
+	minOccurrences := (successfulProbes / 2) + 1 // majority threshold
+	for ip, count := range wildcardIPs {
+		if count >= minOccurrences {
+			wildcards = append(wildcards, ip)
+		}
+	}
+
+	// Cache the result
+	a.cacheLock.Lock()
+	// Double-check in case another goroutine cached while we were probing
+	if existingIPs, ok := a.cache[baseDomain]; ok {
+		a.cacheLock.Unlock()
+		return existingIPs
+	}
+	a.cache[baseDomain] = wildcards
+	a.cacheLock.Unlock()
+
+	return wildcards
+}
+
+// IsWildcard checks if the given host's IPs match known wildcard IPs for its base domain.
+// It accepts both IPv4 (A record) and IPv6 (AAAA record) addresses.
+// Returns true if any of the provided IPs match the detected wildcard pattern.
+func (a *AutoWildcardDetector) IsWildcard(host string, ips []string) bool {
+	baseDomain := a.GetBaseDomain(host)
+
+	// Get or detect wildcard IPs for this base domain
+	wildcardIPs := a.DetectWildcard(baseDomain)
+	if len(wildcardIPs) == 0 {
+		return false
+	}
+
+	// Create a set of wildcard IPs for fast lookup
+	wildcardSet := make(map[string]struct{})
+	for _, wip := range wildcardIPs {
+		wildcardSet[wip] = struct{}{}
+	}
+
+	// Check if any of the host's IPs match wildcard IPs
+	for _, ip := range ips {
+		if _, ok := wildcardSet[ip]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetWildcardDomains returns all detected wildcard domains and their associated IPs.
+// Only domains with detected wildcard IPs are included in the result.
+func (a *AutoWildcardDetector) GetWildcardDomains() map[string][]string {
+	a.cacheLock.RLock()
+	defer a.cacheLock.RUnlock()
+
+	result := make(map[string][]string, len(a.cache))
+	for k, v := range a.cache {
+		if len(v) > 0 {
+			copied := make([]string, len(v))
+			copy(copied, v)
+			result[k] = copied
+		}
+	}
+	return result
+}

--- a/internal/runner/autowildcard_test.go
+++ b/internal/runner/autowildcard_test.go
@@ -1,0 +1,95 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBaseDomain(t *testing.T) {
+	detector := &AutoWildcardDetector{
+		cache:     make(map[string][]string),
+		threshold: 5,
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"www.google.com", "google.com"},
+		{"api.subdomain.google.com", "google.com"},
+		{"example.co.uk", "example.co.uk"},
+		{"test.example.co.uk", "example.co.uk"},
+		{"localhost", "localhost"},
+		{"simple.com", "simple.com"},
+		{"www.google.com.", "google.com"}, // FQDN with trailing dot
+		{"api.github.com.", "github.com"}, // Another FQDN case
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := detector.GetBaseDomain(test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestIsWildcardWithNoWildcards(t *testing.T) {
+	detector := &AutoWildcardDetector{
+		cache:     make(map[string][]string),
+		threshold: 5,
+	}
+
+	// Empty cache means no wildcards detected
+	detector.cache["example.com"] = []string{}
+
+	result := detector.IsWildcard("test.example.com", []string{"1.2.3.4"})
+	assert.False(t, result, "Should return false when no wildcard IPs are cached")
+}
+
+func TestIsWildcardWithMatchingIP(t *testing.T) {
+	detector := &AutoWildcardDetector{
+		cache:     make(map[string][]string),
+		threshold: 5,
+	}
+
+	// Simulate detected wildcard IPs
+	detector.cache["example.com"] = []string{"10.0.0.1", "10.0.0.2"}
+
+	// Should detect as wildcard when IP matches
+	result := detector.IsWildcard("test.example.com", []string{"10.0.0.1"})
+	assert.True(t, result, "Should return true when IP matches wildcard")
+
+	// Should not detect as wildcard when IP doesn't match
+	result = detector.IsWildcard("test.example.com", []string{"192.168.1.1"})
+	assert.False(t, result, "Should return false when IP doesn't match wildcard")
+}
+
+func TestDetectWildcardWithNilRunner(t *testing.T) {
+	// Test that DetectWildcard handles nil runner gracefully
+	detector := &AutoWildcardDetector{
+		runner:    nil, // nil runner
+		cache:     make(map[string][]string),
+		threshold: 5,
+	}
+
+	// Should return nil without panicking
+	result := detector.DetectWildcard("example.com")
+	assert.Nil(t, result, "Should return nil when runner is nil")
+}
+
+func TestDetectWildcardWithNilDnsx(t *testing.T) {
+	// Test that DetectWildcard handles nil dnsx gracefully
+	runner := &Runner{
+		dnsx: nil, // nil dnsx
+	}
+	detector := &AutoWildcardDetector{
+		runner:    runner,
+		cache:     make(map[string][]string),
+		threshold: 5,
+	}
+
+	// Should return nil without panicking
+	result := detector.DetectWildcard("example.com")
+	assert.Nil(t, result, "Should return nil when dnsx is nil")
+}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	TraceMaxRecursion     int
 	WildcardThreshold     int
 	WildcardDomain        string
+	AutoWildcard          bool
 	ShowStatistics        bool
 	rcodes                map[int]struct{}
 	RCode                 string
@@ -189,6 +190,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatically detect and filter wildcard subdomains"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "proxy to use (eg socks5://127.0.0.1:8080)"),
 	)
 
@@ -310,6 +312,14 @@ func (options *Options) validateOptions() {
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")
 		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
+		}
+	}
+
+	// Validate auto-wildcard is not used with wildcard-domain
+	if options.AutoWildcard && options.WildcardDomain != "" {
+		gologger.Fatal().Msgf("auto-wildcard can't be used with wildcard-domain")
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,22 +32,23 @@ import (
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
-	options             *Options
-	dnsx                *dnsx.DNSX
-	wgoutputworker      *sync.WaitGroup
-	wgresolveworkers    *sync.WaitGroup
-	wgwildcardworker    *sync.WaitGroup
-	workerchan          chan string
-	outputchan          chan string
-	wildcardworkerchan  chan string
-	wildcards           *mapsutil.SyncLockMap[string, struct{}]
-	wildcardscache      map[string][]string
-	wildcardscachemutex sync.Mutex
-	limiter             *ratelimit.Limiter
-	hm                  *hybrid.HybridMap
-	stats               clistats.StatisticsClient
-	tmpStdinFile        string
-	aurora              aurora.Aurora
+	options              *Options
+	dnsx                 *dnsx.DNSX
+	wgoutputworker       *sync.WaitGroup
+	wgresolveworkers     *sync.WaitGroup
+	wgwildcardworker     *sync.WaitGroup
+	workerchan           chan string
+	outputchan           chan string
+	wildcardworkerchan   chan string
+	wildcards            *mapsutil.SyncLockMap[string, struct{}]
+	wildcardscache       map[string][]string
+	wildcardscachemutex  sync.Mutex
+	limiter              *ratelimit.Limiter
+	hm                   *hybrid.HybridMap
+	stats                clistats.StatisticsClient
+	tmpStdinFile         string
+	aurora               aurora.Aurora
+	autoWildcardDetector *AutoWildcardDetector
 }
 
 func New(options *Options) (*Runner, error) {
@@ -163,6 +164,11 @@ func New(options *Options) (*Runner, error) {
 		hm:                 hm,
 		stats:              stats,
 		aurora:             aurora.NewAurora(!options.NoColor),
+	}
+
+	// Initialize auto-wildcard detector if enabled
+	if options.AutoWildcard {
+		r.autoWildcardDetector = NewAutoWildcardDetector(&r, options.WildcardThreshold)
 	}
 
 	return &r, nil
@@ -663,6 +669,17 @@ func (r *Runner) worker() {
 				if _, ok := r.options.rcodes[dnsData.StatusCodeRaw]; !ok {
 					continue
 				}
+			}
+		}
+
+		// Auto-wildcard filtering (checks both A and AAAA records)
+		if r.options.AutoWildcard && r.autoWildcardDetector != nil {
+			// Combine A and AAAA records for wildcard check
+			allIPs := make([]string, 0, len(dnsData.A)+len(dnsData.AAAA))
+			allIPs = append(allIPs, dnsData.A...)
+			allIPs = append(allIPs, dnsData.AAAA...)
+			if r.autoWildcardDetector.IsWildcard(domain, allIPs) {
+				continue // skip wildcard results
 			}
 		}
 


### PR DESCRIPTION
## Summary
Implements automatic wildcard DNS detection similar to PureDNS, as requested in #924.

## Changes
- Added new `--auto-wildcard` (`-aw`) flag
- Created `AutoWildcardDetector` that:
  - Automatically extracts base domains (eTLD+1) from input hostnames
  - Probes random subdomains to detect wildcard DNS patterns
  - Caches wildcard IPs per base domain for efficiency
  - Filters results that match wildcard IP patterns
- Added unit tests for the new functionality

## Usage
```bash
# Automatically detect and filter wildcard subdomains
cat subdomains.txt | dnsx -aw -silent

# Combine with existing threshold flag
cat subdomains.txt | dnsx -aw -wt 3 -silent
```

## How it works
1. For each unique base domain in the input, the detector probes N random subdomains (default 5, configurable via `-wt`)
2. IPs that appear in the majority of random probes are flagged as wildcard IPs
3. Any input domain resolving to a wildcard IP is filtered from output

## Testing
- Added unit tests for `GetBaseDomain` and `IsWildcard` functions
- Manual testing confirms filtering works correctly on domains with wildcard DNS

Resolves #924

/cc @dogancanbakir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an --auto-wildcard flag to enable automatic, cached wildcard subdomain detection with a configurable probe threshold and runtime filtering to reduce false-positive DNS results.

* **Validation**
  * --auto-wildcard is disallowed in stream mode and cannot be used together with wildcard-domain.

* **Tests**
  * Added unit tests for base-domain extraction and wildcard detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->