### PR TITLE
feat: Add auto wildcard detection flag (--wildcard-detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ CONFIGURATIONS:
    -r, -resolver string          list of resolvers to use (file or comma separated)
    -wt, -wildcard-threshold int  wildcard filter threshold (default 5)
    -wd, -wildcard-domain string  domain name for wildcard filtering (other flags will be ignored - only json output is supported)
+   -wda, -wildcard-detection      enable automatic wildcard detection and filtering
 ```
 
 ## Running dnsx
@@ -403,6 +404,20 @@ A special feature of `dnsx` is its ability to handle **multi-level DNS based wil
 
 ```console
 dnsx -l subdomain_list.txt -wd airbnb.com -o output.txt
+```
+
+#### Automatic Wildcard Detection
+
+For cases where you don't know the wildcard domain in advance, `dnsx` supports **automatic wildcard detection** using the `-wda` flag. This probes random subdomains of each parent domain to identify wildcard DNS records, similar to how [PureDNS](https://github.com/d3mondev/puredns) eliminates false positives.
+
+```console
+subfinder -silent -d example.com | dnsx -silent -wda
+```
+
+Automatic detection works with all output modes (plain, JSON, response) and is compatible with stream mode. Use `-wt` to tune the detection threshold (default: 5).
+
+```console
+cat subdomains.txt | dnsx -silent -wda -wt 3 -resp
 ```
 
 ---------

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -79,6 +79,7 @@ type Options struct {
 	DisableUpdateCheck    bool
 	PdcpAuth              string
 	Proxy                 string
+	WildcardDetection     bool
 }
 
 // ShouldLoadResume resume file
@@ -141,6 +142,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ResponseOnly, "resp-only", "ro", false, "display dns response only"),
 		flagSet.StringVarP(&options.RCode, "rcode", "rc", "", "filter result by dns status code (eg. -rcode noerror,servfail,refused)"),
 		flagSet.StringVarP(&options.ResponseTypeFilter, "response-type-filter", "rtf", "", "return entries with no records for the specified query types (e.g., a, cname)"),
+		flagSet.BoolVarP(&options.WildcardDetection, "wildcard-detection", "wda", false, "enable automatic wildcard detection and filtering"),
 	)
 
 	flagSet.CreateGroup("probe", "Probe",

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -269,6 +269,10 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
 	}
 
+	if options.WildcardDomain != "" && options.WildcardDetection {
+		gologger.Fatal().Msg("wildcard-domain(-wd) and wildcard-detection(-wda) can't be used at the same time")
+	}
+
 	if options.Retries == 0 {
 		gologger.Fatal().Msgf("retries must be at least 1")
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -48,6 +48,7 @@ type Runner struct {
 	stats               clistats.StatisticsClient
 	tmpStdinFile        string
 	aurora              aurora.Aurora
+	wildcardDetector    *WildcardDetector
 }
 
 func New(options *Options) (*Runner, error) {
@@ -163,6 +164,11 @@ func New(options *Options) (*Runner, error) {
 		hm:                 hm,
 		stats:              stats,
 		aurora:             aurora.NewAurora(!options.NoColor),
+	}
+
+	if options.WildcardDetection {
+		r.wildcardDetector = NewWildcardDetector(dnsX, options.WildcardThreshold)
+		gologger.Info().Msgf("Automatic wildcard detection enabled (threshold: %d)\n", options.WildcardThreshold)
 	}
 
 	return &r, nil
@@ -467,6 +473,14 @@ func (r *Runner) run() error {
 	close(r.outputchan)
 	r.wgoutputworker.Wait()
 
+	// report automatic wildcard detection stats
+	if r.wildcardDetector != nil {
+		filtered := r.wildcardDetector.FilteredCount()
+		if filtered > 0 {
+			gologger.Info().Msgf("%d wildcard subdomains automatically filtered\n", filtered)
+		}
+	}
+
 	if r.options.WildcardDomain != "" {
 		gologger.Print().Msgf("Starting to filter wildcard subdomains\n")
 		ipDomain := make(map[string]map[string]struct{})
@@ -579,6 +593,14 @@ func (r *Runner) runStream() error {
 
 	close(r.outputchan)
 	r.wgoutputworker.Wait()
+
+	// report automatic wildcard detection stats for stream mode
+	if r.wildcardDetector != nil {
+		filtered := r.wildcardDetector.FilteredCount()
+		if filtered > 0 {
+			gologger.Info().Msgf("%d wildcard subdomains automatically filtered\n", filtered)
+		}
+	}
 
 	return nil
 }
@@ -730,6 +752,16 @@ func (r *Runner) worker() {
 				}
 			}
 		}
+
+		// automatic wildcard detection: filter responses matching wildcard IPs
+		if r.wildcardDetector != nil {
+			allIPs := append(dnsData.A, dnsData.AAAA...)
+			if len(allIPs) > 0 && r.wildcardDetector.IsWildcardResponse(domain, allIPs) {
+				gologger.Debug().Msgf("Wildcard filtered: %s\n", domain)
+				continue
+			}
+		}
+
 		// if wildcard filtering just store the data
 		if r.options.WildcardDomain != "" {
 			if err := r.storeDNSData(dnsData.DNSData); err != nil {

--- a/internal/runner/wildcard.go
+++ b/internal/runner/wildcard.go
@@ -2,9 +2,179 @@ package runner
 
 import (
 	"strings"
+	"sync"
+	"sync/atomic"
 
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/gologger"
 	"github.com/rs/xid"
 )
+
+const (
+	// defaultNumProbes is the number of random subdomain probes used to detect a wildcard.
+	defaultNumProbes = 3
+)
+
+// wildcardCacheEntry stores the result of a wildcard probe for a parent domain.
+type wildcardCacheEntry struct {
+	isWildcard bool
+	ips        map[string]struct{} // set of wildcard IPs (empty if not a wildcard)
+}
+
+// WildcardDetector performs automatic wildcard DNS detection by probing
+// random subdomains of parent domains and caching the results.
+type WildcardDetector struct {
+	dnsClient *dnsx.DNSX
+	cache     map[string]*wildcardCacheEntry
+	mu        sync.RWMutex
+	threshold int // minimum number of probes that must agree
+	numProbes int
+	filtered  atomic.Int64
+}
+
+// NewWildcardDetector creates a new automatic wildcard detector.
+func NewWildcardDetector(dnsClient *dnsx.DNSX, threshold int) *WildcardDetector {
+	if threshold < 2 {
+		threshold = 2
+	}
+	return &WildcardDetector{
+		dnsClient: dnsClient,
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: threshold,
+		numProbes: defaultNumProbes,
+	}
+}
+
+// parentDomains returns the possible parent domains for a hostname.
+// For "a.b.example.com" it returns ["b.example.com", "example.com"].
+func parentDomains(host string) []string {
+	parts := strings.Split(host, ".")
+	if len(parts) <= 2 {
+		// Already a root domain (example.com) — no parent to check.
+		return nil
+	}
+	var parents []string
+	for i := 1; i < len(parts)-1; i++ {
+		parents = append(parents, strings.Join(parts[i:], "."))
+	}
+	return parents
+}
+
+// detectWildcardForDomain probes a parent domain with random subdomains.
+// Returns a cache entry indicating whether a wildcard was detected and which IPs it resolves to.
+func (wd *WildcardDetector) detectWildcardForDomain(parentDomain string) *wildcardCacheEntry {
+	ipCounts := make(map[string]int)
+	successfulProbes := 0
+
+	for i := 0; i < wd.numProbes; i++ {
+		randomHost := xid.New().String() + "." + parentDomain
+		result, err := wd.dnsClient.QueryOne(randomHost)
+		if err != nil || result == nil {
+			continue
+		}
+		// Collect both A and AAAA records
+		allIPs := append(result.A, result.AAAA...)
+		if len(allIPs) == 0 {
+			continue
+		}
+		successfulProbes++
+		for _, ip := range allIPs {
+			ipCounts[ip]++
+		}
+	}
+
+	entry := &wildcardCacheEntry{
+		ips: make(map[string]struct{}),
+	}
+
+	// If at least 2 probes returned results, and common IPs are found, it's a wildcard.
+	minAgreement := wd.threshold
+	if minAgreement > wd.numProbes {
+		minAgreement = wd.numProbes
+	}
+	if minAgreement < 2 {
+		minAgreement = 2
+	}
+	if successfulProbes >= minAgreement {
+		for ip, count := range ipCounts {
+			if count >= minAgreement {
+				entry.ips[ip] = struct{}{}
+			}
+		}
+		if len(entry.ips) > 0 {
+			entry.isWildcard = true
+			gologger.Debug().Msgf("Wildcard detected for *.%s (IPs: %v)\n", parentDomain, mapsToSlice(entry.ips))
+		}
+	}
+
+	return entry
+}
+
+// getOrDetect retrieves the cached wildcard entry for a parent domain,
+// or probes and caches the result.
+func (wd *WildcardDetector) getOrDetect(parentDomain string) *wildcardCacheEntry {
+	wd.mu.RLock()
+	entry, ok := wd.cache[parentDomain]
+	wd.mu.RUnlock()
+	if ok {
+		return entry
+	}
+
+	// Probe and cache
+	entry = wd.detectWildcardForDomain(parentDomain)
+	wd.mu.Lock()
+	// Double-check after acquiring write lock
+	if existing, ok := wd.cache[parentDomain]; ok {
+		wd.mu.Unlock()
+		return existing
+	}
+	wd.cache[parentDomain] = entry
+	wd.mu.Unlock()
+	return entry
+}
+
+// IsWildcardResponse checks if a resolved host's IPs match a wildcard
+// on any of its parent domains. Returns true if the response should be filtered out.
+func (wd *WildcardDetector) IsWildcardResponse(host string, resolvedIPs []string) bool {
+	if len(resolvedIPs) == 0 {
+		return false
+	}
+
+	parents := parentDomains(host)
+	for _, parent := range parents {
+		entry := wd.getOrDetect(parent)
+		if !entry.isWildcard {
+			continue
+		}
+		// Check if ALL resolved IPs are wildcard IPs
+		allMatch := true
+		for _, ip := range resolvedIPs {
+			if _, ok := entry.ips[ip]; !ok {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			wd.filtered.Add(1)
+			return true
+		}
+	}
+	return false
+}
+
+// FilteredCount returns the number of wildcard responses that were filtered.
+func (wd *WildcardDetector) FilteredCount() int64 {
+	return wd.filtered.Load()
+}
+
+// mapsToSlice converts a map[string]struct{} to a string slice (for logging).
+func mapsToSlice(m map[string]struct{}) []string {
+	result := make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
+}
 
 // IsWildcard checks if a host is wildcard
 func (r *Runner) IsWildcard(host string) bool {

--- a/internal/runner/wildcard.go
+++ b/internal/runner/wildcard.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/miekg/dns"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/projectdiscovery/gologger"
 	"github.com/rs/xid"
@@ -68,7 +69,10 @@ func (wd *WildcardDetector) detectWildcardForDomain(parentDomain string) *wildca
 
 	for i := 0; i < wd.numProbes; i++ {
 		randomHost := xid.New().String() + "." + parentDomain
-		result, err := wd.dnsClient.QueryOne(randomHost)
+
+		// Explicitly query for both A and AAAA to catch all wildcard types
+		// regardless of what the user selected for the main scan.
+		result, err := wd.dnsClient.QueryWithTypes(randomHost, []uint16{dns.TypeA, dns.TypeAAAA})
 		if err != nil || result == nil {
 			continue
 		}

--- a/internal/runner/wildcard.go
+++ b/internal/runner/wildcard.go
@@ -72,8 +72,11 @@ func (wd *WildcardDetector) detectWildcardForDomain(parentDomain string) *wildca
 		if err != nil || result == nil {
 			continue
 		}
-		// Collect both A and AAAA records
-		allIPs := append(result.A, result.AAAA...)
+		// Collect both A and AAAA records without modifying originals
+		allIPs := make([]string, 0, len(result.A)+len(result.AAAA))
+		allIPs = append(allIPs, result.A...)
+		allIPs = append(allIPs, result.AAAA...)
+
 		if len(allIPs) == 0 {
 			continue
 		}

--- a/internal/runner/wildcard_test.go
+++ b/internal/runner/wildcard_test.go
@@ -1,0 +1,224 @@
+package runner
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParentDomains(t *testing.T) {
+	tests := []struct {
+		host     string
+		expected []string
+	}{
+		{
+			host:     "a.b.example.com",
+			expected: []string{"b.example.com", "example.com"},
+		},
+		{
+			host:     "sub.example.com",
+			expected: []string{"example.com"},
+		},
+		{
+			host:     "example.com",
+			expected: nil,
+		},
+		{
+			host:     "a.b.c.d.example.com",
+			expected: []string{"b.c.d.example.com", "c.d.example.com", "d.example.com", "example.com"},
+		},
+		{
+			host:     "com",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			got := parentDomains(tt.host)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestMapsToSlice(t *testing.T) {
+	m := map[string]struct{}{
+		"1.2.3.4": {},
+		"5.6.7.8": {},
+	}
+	result := mapsToSlice(m)
+	require.Len(t, result, 2)
+	require.Contains(t, result, "1.2.3.4")
+	require.Contains(t, result, "5.6.7.8")
+}
+
+func TestWildcardDetector_IsWildcardResponse_NoParent(t *testing.T) {
+	// For a root domain (e.g., example.com), parentDomains returns nil,
+	// so IsWildcardResponse should return false.
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+	// no DNS client set — but since there's no parent domain to probe, it won't be called
+	result := wd.IsWildcardResponse("example.com", []string{"1.2.3.4"})
+	require.False(t, result, "root domain should not be detected as wildcard")
+}
+
+func TestWildcardDetector_CachedWildcard(t *testing.T) {
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+
+	// Pre-populate cache with a known wildcard entry
+	wd.cache["example.com"] = &wildcardCacheEntry{
+		isWildcard: true,
+		ips:        map[string]struct{}{"1.2.3.4": {}, "5.6.7.8": {}},
+	}
+
+	// Should detect sub.example.com resolving to wildcard IPs
+	result := wd.IsWildcardResponse("sub.example.com", []string{"1.2.3.4"})
+	require.True(t, result, "should detect wildcard from cached entry")
+
+	// Should NOT filter if IP is different from wildcard
+	result = wd.IsWildcardResponse("sub.example.com", []string{"9.9.9.9"})
+	require.False(t, result, "should not filter non-wildcard IP")
+
+	// Should NOT filter if only some IPs match wildcard
+	result = wd.IsWildcardResponse("sub.example.com", []string{"1.2.3.4", "9.9.9.9"})
+	require.False(t, result, "should not filter partial wildcard match")
+
+	// Should filter if all IPs match wildcard
+	result = wd.IsWildcardResponse("sub.example.com", []string{"1.2.3.4", "5.6.7.8"})
+	require.True(t, result, "should filter when all IPs match wildcard")
+}
+
+func TestWildcardDetector_CachedNonWildcard(t *testing.T) {
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+
+	// Pre-populate cache with a non-wildcard entry
+	wd.cache["example.com"] = &wildcardCacheEntry{
+		isWildcard: false,
+		ips:        map[string]struct{}{},
+	}
+
+	result := wd.IsWildcardResponse("sub.example.com", []string{"1.2.3.4"})
+	require.False(t, result, "non-wildcard domain should not be filtered")
+}
+
+func TestWildcardDetector_FilteredCount(t *testing.T) {
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+
+	wd.cache["example.com"] = &wildcardCacheEntry{
+		isWildcard: true,
+		ips:        map[string]struct{}{"1.2.3.4": {}},
+	}
+
+	require.Equal(t, int64(0), wd.FilteredCount())
+
+	wd.IsWildcardResponse("a.example.com", []string{"1.2.3.4"})
+	require.Equal(t, int64(1), wd.FilteredCount())
+
+	wd.IsWildcardResponse("b.example.com", []string{"1.2.3.4"})
+	require.Equal(t, int64(2), wd.FilteredCount())
+
+	// Non-matching should not increment
+	wd.IsWildcardResponse("c.example.com", []string{"9.9.9.9"})
+	require.Equal(t, int64(2), wd.FilteredCount())
+}
+
+func TestWildcardDetector_EmptyIPs(t *testing.T) {
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+
+	wd.cache["example.com"] = &wildcardCacheEntry{
+		isWildcard: true,
+		ips:        map[string]struct{}{"1.2.3.4": {}},
+	}
+
+	// Empty resolved IPs should return false
+	result := wd.IsWildcardResponse("sub.example.com", []string{})
+	require.False(t, result, "empty IPs should not be considered wildcard")
+
+	result = wd.IsWildcardResponse("sub.example.com", nil)
+	require.False(t, result, "nil IPs should not be considered wildcard")
+}
+
+func TestWildcardDetector_NestedSubdomain(t *testing.T) {
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+
+	// Wildcard only on deeper subdomain level
+	wd.cache["sub.example.com"] = &wildcardCacheEntry{
+		isWildcard: true,
+		ips:        map[string]struct{}{"10.0.0.1": {}},
+	}
+	wd.cache["example.com"] = &wildcardCacheEntry{
+		isWildcard: false,
+		ips:        map[string]struct{}{},
+	}
+
+	// a.sub.example.com should be filtered (parent sub.example.com is wildcard)
+	result := wd.IsWildcardResponse("a.sub.example.com", []string{"10.0.0.1"})
+	require.True(t, result, "nested wildcard should be detected")
+
+	// a.example.com should NOT be filtered (parent example.com is not wildcard)
+	result = wd.IsWildcardResponse("a.example.com", []string{"10.0.0.1"})
+	require.False(t, result, "non-wildcard parent should not filter")
+}
+
+func TestWildcardDetector_ConcurrentAccess(t *testing.T) {
+	wd := &WildcardDetector{
+		cache:     make(map[string]*wildcardCacheEntry),
+		threshold: 2,
+		numProbes: 3,
+	}
+
+	wd.cache["example.com"] = &wildcardCacheEntry{
+		isWildcard: true,
+		ips:        map[string]struct{}{"1.2.3.4": {}},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			host := fmt.Sprintf("sub%d.example.com", n)
+			wd.IsWildcardResponse(host, []string{"1.2.3.4"})
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(100), wd.FilteredCount(), "all concurrent accesses should be filtered")
+}
+
+func TestNewWildcardDetector_ThresholdClamping(t *testing.T) {
+	// Threshold below 2 should be clamped to 2
+	wd := NewWildcardDetector(nil, 0)
+	require.Equal(t, 2, wd.threshold)
+
+	wd = NewWildcardDetector(nil, 1)
+	require.Equal(t, 2, wd.threshold)
+
+	wd = NewWildcardDetector(nil, 5)
+	require.Equal(t, 5, wd.threshold)
+}

--- a/libs/dnsx/dnsx.go
+++ b/libs/dnsx/dnsx.go
@@ -156,9 +156,14 @@ func (d *DNSX) QueryMultiple(hostname string) (*retryabledns.DNSData, error) {
 // Trace performs a DNS trace of the specified types and returns raw responses
 func (d *DNSX) Trace(hostname string) (*retryabledns.TraceData, error) {
 	if len(d.Options.QuestionTypes) == 0 {
-    	return nil, errors.New("no question types specified for trace")
-    }
+		return nil, errors.New("no question types specified for trace")
+	}
 	return d.dnsClient.Trace(hostname, d.Options.QuestionTypes[0], d.Options.TraceMaxRecursion)
+}
+
+// QueryWithTypes performs a DNS question of the specified types and returns raw responses
+func (d *DNSX) QueryWithTypes(hostname string, types []uint16) (*retryabledns.DNSData, error) {
+	return d.dnsClient.QueryMultiple(hostname, types)
 }
 
 // Trace performs a DNS trace of the specified types and returns raw responses


### PR DESCRIPTION
This PR implements automatic wildcard DNS detection across multiple domains, following the request in issue #924.
/claim 938

### ✅ Changes
- Added `--wildcard-detection` / `-wda` flag
- Detects wildcard domains using random subdomain probing
- Filters out wildcard results automatically
- Caches results per root domain for efficiency
- Supports both A and AAAA records
- Tests included for domains with and without wildcard

### 🧪 Proof
- Tested with domains having wildcard (*.example.com) and regular domains
- Verified that existing flags and functionality remain unchanged
- All checks passed (lint, unit tests)

### 📌 Implementation Details
- New `WildcardDetector` struct with thread-safe cache and configurable threshold
- Probes 3 random subdomains per parent domain to identify wildcard patterns
- Filters only when ALL resolved IPs match wildcard IPs (avoids false positives)
- Works with all output modes (plain, JSON, response) and stream mode
- Zero overhead when `-wda` is not used (opt-in only)

Closes #924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic wildcard detection (-wda / --wildcard-detection) with configurable threshold (-wt) and runtime reporting of filtered wildcard subdomains.

* **Documentation**
  * Added "Automatic Wildcard Detection" section with usage, examples, output-mode notes, and threshold tuning.

* **Bug Fixes**
  * Validation now prevents using automatic wildcard detection together with an explicitly configured wildcard domain.

* **Tests**
  * Added comprehensive unit tests covering detection logic, caching, concurrency, and threshold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->