### PR TITLE
feat(dnsx): add --auto-wildcard to detect & filter wildcards

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	TraceMaxRecursion     int
 	WildcardThreshold     int
 	WildcardDomain        string
+	AutoWildcard          bool
 	ShowStatistics        bool
 	rcodes                map[int]struct{}
 	RCode                 string
@@ -141,6 +142,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ResponseOnly, "resp-only", "ro", false, "display dns response only"),
 		flagSet.StringVarP(&options.RCode, "rcode", "rc", "", "filter result by dns status code (eg. -rcode noerror,servfail,refused)"),
 		flagSet.StringVarP(&options.ResponseTypeFilter, "response-type-filter", "rtf", "", "return entries with no records for the specified query types (e.g., a, cname)"),
+		flagSet.BoolVar(&options.AutoWildcard, "auto-wildcard", false, "automatically detect and filter wildcard dns per root domain"),
 	)
 
 	flagSet.CreateGroup("probe", "Probe",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,22 +32,25 @@ import (
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
-	options             *Options
-	dnsx                *dnsx.DNSX
-	wgoutputworker      *sync.WaitGroup
-	wgresolveworkers    *sync.WaitGroup
-	wgwildcardworker    *sync.WaitGroup
-	workerchan          chan string
-	outputchan          chan string
-	wildcardworkerchan  chan string
-	wildcards           *mapsutil.SyncLockMap[string, struct{}]
-	wildcardscache      map[string][]string
-	wildcardscachemutex sync.Mutex
-	limiter             *ratelimit.Limiter
-	hm                  *hybrid.HybridMap
-	stats               clistats.StatisticsClient
-	tmpStdinFile        string
-	aurora              aurora.Aurora
+	options              *Options
+	dnsx                 *dnsx.DNSX
+	wgoutputworker       *sync.WaitGroup
+	wgresolveworkers     *sync.WaitGroup
+	wgwildcardworker     *sync.WaitGroup
+	workerchan           chan string
+	outputchan           chan string
+	wildcardworkerchan   chan string
+	wildcards            *mapsutil.SyncLockMap[string, struct{}]
+	wildcardscache       map[string][]string
+	wildcardscachemutex  sync.Mutex
+	autoWildcardCache    map[string]wildcardFingerprint
+	autoWildcardMutex    sync.Mutex
+	autoWildcardResolver wildcardQueryer
+	limiter              *ratelimit.Limiter
+	hm                   *hybrid.HybridMap
+	stats                clistats.StatisticsClient
+	tmpStdinFile         string
+	aurora               aurora.Aurora
 }
 
 func New(options *Options) (*Runner, error) {
@@ -150,19 +153,21 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	r := Runner{
-		options:            options,
-		dnsx:               dnsX,
-		wgoutputworker:     &sync.WaitGroup{},
-		wgresolveworkers:   &sync.WaitGroup{},
-		wgwildcardworker:   &sync.WaitGroup{},
-		workerchan:         make(chan string),
-		wildcardworkerchan: make(chan string),
-		wildcards:          mapsutil.NewSyncLockMap[string, struct{}](),
-		wildcardscache:     make(map[string][]string),
-		limiter:            limiter,
-		hm:                 hm,
-		stats:              stats,
-		aurora:             aurora.NewAurora(!options.NoColor),
+		options:              options,
+		dnsx:                 dnsX,
+		wgoutputworker:       &sync.WaitGroup{},
+		wgresolveworkers:     &sync.WaitGroup{},
+		wgwildcardworker:     &sync.WaitGroup{},
+		workerchan:           make(chan string),
+		wildcardworkerchan:   make(chan string),
+		wildcards:            mapsutil.NewSyncLockMap[string, struct{}](),
+		wildcardscache:       make(map[string][]string),
+		autoWildcardCache:    make(map[string]wildcardFingerprint),
+		autoWildcardResolver: dnsX,
+		limiter:              limiter,
+		hm:                   hm,
+		stats:                stats,
+		aurora:               aurora.NewAurora(!options.NoColor),
 	}
 
 	return &r, nil
@@ -727,6 +732,15 @@ func (r *Runner) worker() {
 				}
 				for _, cidr := range cidrs {
 					dnsData.ASN.AsRange = append(dnsData.ASN.AsRange, cidr.String())
+				}
+			}
+		}
+		if r.options.AutoWildcard && r.options.WildcardDomain == "" {
+			domainNormalized := strings.ToLower(strings.TrimSuffix(domain, "."))
+			root := extractRootDomain(domainNormalized)
+			if root != "" && domainNormalized != root {
+				if r.matchesAutoWildcard(root, dnsData.DNSData) {
+					continue
 				}
 			}
 		}

--- a/internal/runner/util.go
+++ b/internal/runner/util.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	fileutil "github.com/projectdiscovery/utils/file"
+	iputil "github.com/projectdiscovery/utils/ip"
+	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
 
 const (
@@ -57,6 +59,18 @@ func prepareResolver(resolver string) string {
 		resolver += ":53"
 	}
 	return resolver
+}
+
+func extractRootDomain(host string) string {
+	host = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(host, ".")))
+	if host == "" || iputil.IsIP(host) {
+		return ""
+	}
+	root, err := publicsuffix.Domain(host)
+	if err != nil {
+		return ""
+	}
+	return root
 }
 
 func fmtDuration(d time.Duration) string {

--- a/internal/runner/wildcard.go
+++ b/internal/runner/wildcard.go
@@ -3,8 +3,28 @@ package runner
 import (
 	"strings"
 
+	"github.com/projectdiscovery/retryabledns"
 	"github.com/rs/xid"
 )
+
+type wildcardFingerprintKind uint8
+
+const (
+	wildcardFingerprintNone wildcardFingerprintKind = iota
+	wildcardFingerprintIP
+	wildcardFingerprintCNAME
+)
+
+type wildcardFingerprint struct {
+	kind   wildcardFingerprintKind
+	values map[string]struct{}
+}
+
+type wildcardQueryer interface {
+	QueryMultiple(host string) (*retryabledns.DNSData, error)
+}
+
+const autoWildcardCheckCount = 3
 
 // IsWildcard checks if a host is wildcard
 func (r *Runner) IsWildcard(host string) bool {
@@ -68,4 +88,123 @@ func (r *Runner) IsWildcard(host string) bool {
 	}
 
 	return false
+}
+
+func (r *Runner) autoWildcardFingerprint(root string) wildcardFingerprint {
+	root = strings.ToLower(strings.TrimSuffix(root, "."))
+	if root == "" {
+		return wildcardFingerprint{}
+	}
+
+	r.autoWildcardMutex.Lock()
+	fp, ok := r.autoWildcardCache[root]
+	r.autoWildcardMutex.Unlock()
+	if ok {
+		return fp
+	}
+
+	fp = r.detectAutoWildcardFingerprint(root)
+
+	r.autoWildcardMutex.Lock()
+	if r.autoWildcardCache == nil {
+		r.autoWildcardCache = make(map[string]wildcardFingerprint)
+	}
+	r.autoWildcardCache[root] = fp
+	r.autoWildcardMutex.Unlock()
+
+	return fp
+}
+
+func (r *Runner) detectAutoWildcardFingerprint(root string) wildcardFingerprint {
+	resolver := r.autoWildcardResolver
+	if resolver == nil {
+		resolver = r.dnsx
+	}
+	if resolver == nil {
+		return wildcardFingerprint{}
+	}
+
+	var base wildcardFingerprint
+	for i := 0; i < autoWildcardCheckCount; i++ {
+		host := xid.New().String() + "." + root
+		in, err := resolver.QueryMultiple(host)
+		if err != nil || in == nil {
+			return wildcardFingerprint{}
+		}
+
+		fp := fingerprintFromDNSData(in)
+		if fp.kind == wildcardFingerprintNone {
+			return wildcardFingerprint{}
+		}
+
+		if i == 0 {
+			base = fp
+			continue
+		}
+		if !fingerprintsEqual(base, fp) {
+			return wildcardFingerprint{}
+		}
+	}
+	return base
+}
+
+func (r *Runner) matchesAutoWildcard(root string, dnsData *retryabledns.DNSData) bool {
+	if dnsData == nil {
+		return false
+	}
+	fp := r.autoWildcardFingerprint(root)
+	if fp.kind == wildcardFingerprintNone {
+		return false
+	}
+	dataFP := fingerprintFromDNSData(dnsData)
+	if dataFP.kind == wildcardFingerprintNone || dataFP.kind != fp.kind {
+		return false
+	}
+	return fingerprintsEqual(fp, dataFP)
+}
+
+func fingerprintFromDNSData(data *retryabledns.DNSData) wildcardFingerprint {
+	if data == nil {
+		return wildcardFingerprint{}
+	}
+	if len(data.CNAME) > 0 {
+		return wildcardFingerprint{
+			kind:   wildcardFingerprintCNAME,
+			values: sliceToSet(data.CNAME),
+		}
+	}
+	if len(data.A) == 0 && len(data.AAAA) == 0 {
+		return wildcardFingerprint{}
+	}
+	values := sliceToSet(data.A)
+	for _, item := range data.AAAA {
+		values[item] = struct{}{}
+	}
+	return wildcardFingerprint{
+		kind:   wildcardFingerprintIP,
+		values: values,
+	}
+}
+
+func sliceToSet(items []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+	return set
+}
+
+func fingerprintsEqual(a, b wildcardFingerprint) bool {
+	if a.kind != b.kind {
+		return false
+	}
+	if len(a.values) != len(b.values) {
+		return false
+	}
+	for item := range a.values {
+		if _, ok := b.values[item]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/runner/wildcard_auto_test.go
+++ b/internal/runner/wildcard_auto_test.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectdiscovery/retryabledns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoWildcardDetectionAndMatch(t *testing.T) {
+	r := &Runner{
+		options:              &Options{AutoWildcard: true},
+		autoWildcardCache:    make(map[string]wildcardFingerprint),
+		autoWildcardResolver: &fakeResolver{},
+	}
+
+	fp := r.autoWildcardFingerprint("wild.test")
+	require.Equal(t, wildcardFingerprintIP, fp.kind)
+	require.ElementsMatch(t, []string{"1.2.3.4"}, setKeys(fp.values))
+
+	wildData, err := r.autoWildcardResolver.QueryMultiple("random.wild.test")
+	require.NoError(t, err)
+	require.True(t, r.matchesAutoWildcard("wild.test", wildData))
+
+	realData, err := r.autoWildcardResolver.QueryMultiple("real.wild.test")
+	require.NoError(t, err)
+	require.False(t, r.matchesAutoWildcard("wild.test", realData))
+
+	fp = r.autoWildcardFingerprint("nowild.test")
+	require.Equal(t, wildcardFingerprintNone, fp.kind)
+}
+
+type fakeResolver struct{}
+
+func (f *fakeResolver) QueryMultiple(host string) (*retryabledns.DNSData, error) {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	switch {
+	case host == "real.wild.test":
+		return &retryabledns.DNSData{Host: host, A: []string{"9.9.9.9"}}, nil
+	case host == "wild.test":
+		return &retryabledns.DNSData{Host: host, A: []string{"5.5.5.5"}}, nil
+	case strings.HasSuffix(host, ".wild.test"):
+		return &retryabledns.DNSData{Host: host, A: []string{"1.2.3.4"}}, nil
+	case host == "real.nowild.test":
+		return &retryabledns.DNSData{Host: host, A: []string{"2.2.2.2"}}, nil
+	case strings.HasSuffix(host, ".nowild.test"):
+		return &retryabledns.DNSData{Host: host}, nil
+	default:
+		return &retryabledns.DNSData{Host: host}, nil
+	}
+}
+
+func setKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/proof_924_tests.txt
+++ b/proof_924_tests.txt
@@ -1,0 +1,4 @@
+=== RUN   TestAutoWildcardDetectionAndMatch
+--- PASS: TestAutoWildcardDetectionAndMatch (0.00s)
+PASS
+ok  	github.com/projectdiscovery/dnsx/internal/runner	1.503s


### PR DESCRIPTION
Fixes #924
/claim #924

## What
Add an opt-in flag to automatically detect wildcard DNS per domain during a single run and filter wildcard-based results, similar to puredns behavior.

## Change
- Add `--auto-wildcard` option
- For each domain, compute and cache a wildcard fingerprint using random subdomain probes
- Filter results that match the cached wildcard fingerprint

## Proof
Offline unit test (no external DNS/network):
```bash
GOCACHE=/tmp/go-build-cache-dnsx go test ./internal/runner -run TestAutoWildcardDetectionAndMatch -count=1 -v
```
Output is attached in `proof_924_tests.txt`.

/claim #924


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--auto-wildcard` CLI flag to enable automatic wildcard DNS filtering behavior, which automatically detects and filters domains matching wildcard patterns without requiring manual configuration.

* **Tests**
  * Added test coverage validating the auto-wildcard detection and matching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->