### PR TITLE
Add automatic wildcard DNS detection and filtering

### DIFF
--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -1,0 +1,175 @@
+package runner
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/rs/xid"
+)
+
+// autoWildcardDetector detects and tracks wildcard DNS domains automatically.
+// For each parent domain encountered during resolution, it sends a configurable
+// number of random subdomain queries. If all probes resolve to the same set of
+// IPs, the parent domain is marked as a wildcard and those IPs are stored.
+// Subsequent results whose A records are a subset of the wildcard set are
+// filtered (or annotated).
+type autoWildcardDetector struct {
+	// wildcardIPs maps parent domain -> set of wildcard IPs
+	wildcardIPs map[string]map[string]struct{}
+	// nonWildcardDomains tracks parent domains confirmed as not wildcard
+	nonWildcardDomains map[string]struct{}
+	mu                 sync.RWMutex
+
+	numProbes int
+	runner    *Runner
+
+	filteredCount atomic.Int64
+}
+
+func newAutoWildcardDetector(r *Runner, numProbes int) *autoWildcardDetector {
+	if numProbes < 2 {
+		numProbes = 2
+	}
+	return &autoWildcardDetector{
+		wildcardIPs:        make(map[string]map[string]struct{}),
+		nonWildcardDomains: make(map[string]struct{}),
+		numProbes:          numProbes,
+		runner:             r,
+	}
+}
+
+// extractParentDomain returns the parent domain of a given FQDN.
+// For "foo.bar.example.com" it returns "bar.example.com".
+// For "sub.example.com" it returns "example.com".
+// For a bare domain like "example.com" it returns "" (nothing to check).
+func extractParentDomain(host string) string {
+	host = strings.TrimSuffix(host, ".")
+	parts := strings.SplitN(host, ".", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	parent := parts[1]
+	// The parent itself must have at least one dot to be a valid domain
+	// (e.g. "example.com" is valid, "com" is not).
+	if !strings.Contains(parent, ".") {
+		return ""
+	}
+	return parent
+}
+
+// isWildcard checks whether the given domain's A records match a known wildcard
+// set for its parent domain. It lazily probes parent domains on first encounter.
+// Returns true if the result should be filtered.
+func (d *autoWildcardDetector) isWildcard(host string, aRecords []string) bool {
+	if len(aRecords) == 0 {
+		return false
+	}
+
+	parent := extractParentDomain(host)
+	if parent == "" {
+		return false
+	}
+
+	d.mu.RLock()
+	_, isNonWildcard := d.nonWildcardDomains[parent]
+	wildcardSet, isKnownWildcard := d.wildcardIPs[parent]
+	d.mu.RUnlock()
+
+	if isNonWildcard {
+		return false
+	}
+
+	if !isKnownWildcard {
+		// First time seeing this parent: probe it
+		wildcardSet = d.probeParent(parent)
+	}
+
+	if wildcardSet == nil {
+		return false
+	}
+
+	// Check if all A records for this host are in the wildcard set
+	for _, ip := range aRecords {
+		if _, ok := wildcardSet[ip]; !ok {
+			return false
+		}
+	}
+	d.filteredCount.Add(1)
+	return true
+}
+
+// probeParent sends random subdomain queries to the parent domain and determines
+// if it has wildcard DNS configured. Thread-safe with double-checked locking.
+func (d *autoWildcardDetector) probeParent(parent string) map[string]struct{} {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Double-check under write lock
+	if _, ok := d.nonWildcardDomains[parent]; ok {
+		return nil
+	}
+	if ips, ok := d.wildcardIPs[parent]; ok {
+		return ips
+	}
+
+	// Send random subdomain queries
+	var allProbeIPs []map[string]struct{}
+	for i := 0; i < d.numProbes; i++ {
+		randomSub := xid.New().String() + "." + parent
+		result, err := d.runner.dnsx.QueryOne(randomSub)
+		if err != nil || result == nil || len(result.A) == 0 {
+			// If any probe fails to resolve, the domain is not wildcard
+			d.nonWildcardDomains[parent] = struct{}{}
+			gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (probe %d got no response)\n", parent, i+1)
+			return nil
+		}
+		ipSet := make(map[string]struct{})
+		for _, a := range result.A {
+			ipSet[a] = struct{}{}
+		}
+		allProbeIPs = append(allProbeIPs, ipSet)
+	}
+
+	// Verify all probes returned the same set of IPs
+	// Build the intersection of all probe results
+	intersection := allProbeIPs[0]
+	for i := 1; i < len(allProbeIPs); i++ {
+		next := make(map[string]struct{})
+		for ip := range intersection {
+			if _, ok := allProbeIPs[i][ip]; ok {
+				next[ip] = struct{}{}
+			}
+		}
+		intersection = next
+	}
+
+	if len(intersection) == 0 {
+		d.nonWildcardDomains[parent] = struct{}{}
+		gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (no common IPs across probes)\n", parent)
+		return nil
+	}
+
+	// Also verify the union is equal to the intersection (all probes returned the same set)
+	union := make(map[string]struct{})
+	for _, probeSet := range allProbeIPs {
+		for ip := range probeSet {
+			union[ip] = struct{}{}
+		}
+	}
+	if len(union) != len(intersection) {
+		d.nonWildcardDomains[parent] = struct{}{}
+		gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (inconsistent IPs across probes)\n", parent)
+		return nil
+	}
+
+	// This parent domain is a wildcard
+	d.wildcardIPs[parent] = intersection
+	ips := make([]string, 0, len(intersection))
+	for ip := range intersection {
+		ips = append(ips, ip)
+	}
+	gologger.Verbose().Msgf("Auto-wildcard: detected %s as wildcard domain (IPs: %v)\n", parent, ips)
+	return intersection
+}

--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/rs/xid"
+	"golang.org/x/sync/singleflight"
 )
 
 // autoWildcardDetector detects and tracks wildcard DNS domains automatically.
@@ -21,6 +22,11 @@ type autoWildcardDetector struct {
 	// nonWildcardDomains tracks parent domains confirmed as not wildcard
 	nonWildcardDomains map[string]struct{}
 	mu                 sync.RWMutex
+
+	// sfGroup deduplicates concurrent probes for the same parent domain
+	// so that only goroutines probing the SAME parent block each other,
+	// while lookups for already-cached parents proceed unimpeded.
+	sfGroup singleflight.Group
 
 	numProbes int
 	runner    *Runner
@@ -72,6 +78,8 @@ func (d *autoWildcardDetector) isWildcard(host string, aRecords []string) bool {
 		return false
 	}
 
+	// Fast path: check the cache under a read lock so that lookups for
+	// already-cached parents proceed without blocking.
 	d.mu.RLock()
 	_, isNonWildcard := d.nonWildcardDomains[parent]
 	wildcardSet, isKnownWildcard := d.wildcardIPs[parent]
@@ -82,7 +90,9 @@ func (d *autoWildcardDetector) isWildcard(host string, aRecords []string) bool {
 	}
 
 	if !isKnownWildcard {
-		// First time seeing this parent: probe it
+		// First time seeing this parent: use singleflight so only
+		// goroutines probing the SAME parent block each other while
+		// DNS queries are in progress.
 		wildcardSet = d.probeParent(parent)
 	}
 
@@ -100,76 +110,98 @@ func (d *autoWildcardDetector) isWildcard(host string, aRecords []string) bool {
 	return true
 }
 
+// probeResult bundles the outcome of probing a parent domain so that it can
+// be returned through singleflight.Do as an interface{}.
+type probeResult struct {
+	wildcardIPs map[string]struct{}
+}
+
 // probeParent sends random subdomain queries to the parent domain and determines
-// if it has wildcard DNS configured. Thread-safe with double-checked locking.
+// if it has wildcard DNS configured. Concurrent callers for the same parent are
+// deduplicated via singleflight; callers for different parents proceed in parallel.
 func (d *autoWildcardDetector) probeParent(parent string) map[string]struct{} {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	v, _, _ := d.sfGroup.Do(parent, func() (interface{}, error) {
+		// Re-check the cache: another goroutine in a previous singleflight
+		// call may have already populated the result.
+		d.mu.RLock()
+		if _, ok := d.nonWildcardDomains[parent]; ok {
+			d.mu.RUnlock()
+			return &probeResult{nil}, nil
+		}
+		if ips, ok := d.wildcardIPs[parent]; ok {
+			d.mu.RUnlock()
+			return &probeResult{ips}, nil
+		}
+		d.mu.RUnlock()
 
-	// Double-check under write lock
-	if _, ok := d.nonWildcardDomains[parent]; ok {
-		return nil
-	}
-	if ips, ok := d.wildcardIPs[parent]; ok {
-		return ips
-	}
+		// Send random subdomain queries (no lock held during DNS I/O).
+		var allProbeIPs []map[string]struct{}
+		for i := 0; i < d.numProbes; i++ {
+			randomSub := xid.New().String() + "." + parent
+			result, err := d.runner.dnsx.QueryOne(randomSub)
+			if err != nil || result == nil || len(result.A) == 0 {
+				// If any probe fails to resolve, the domain is not wildcard
+				d.mu.Lock()
+				d.nonWildcardDomains[parent] = struct{}{}
+				d.mu.Unlock()
+				gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (probe %d got no response)\n", parent, i+1)
+				return &probeResult{nil}, nil
+			}
+			ipSet := make(map[string]struct{})
+			for _, a := range result.A {
+				ipSet[a] = struct{}{}
+			}
+			allProbeIPs = append(allProbeIPs, ipSet)
+		}
 
-	// Send random subdomain queries
-	var allProbeIPs []map[string]struct{}
-	for i := 0; i < d.numProbes; i++ {
-		randomSub := xid.New().String() + "." + parent
-		result, err := d.runner.dnsx.QueryOne(randomSub)
-		if err != nil || result == nil || len(result.A) == 0 {
-			// If any probe fails to resolve, the domain is not wildcard
+		// Verify all probes returned the same set of IPs
+		// Build the intersection of all probe results
+		intersection := allProbeIPs[0]
+		for i := 1; i < len(allProbeIPs); i++ {
+			next := make(map[string]struct{})
+			for ip := range intersection {
+				if _, ok := allProbeIPs[i][ip]; ok {
+					next[ip] = struct{}{}
+				}
+			}
+			intersection = next
+		}
+
+		if len(intersection) == 0 {
+			d.mu.Lock()
 			d.nonWildcardDomains[parent] = struct{}{}
-			gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (probe %d got no response)\n", parent, i+1)
-			return nil
+			d.mu.Unlock()
+			gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (no common IPs across probes)\n", parent)
+			return &probeResult{nil}, nil
 		}
-		ipSet := make(map[string]struct{})
-		for _, a := range result.A {
-			ipSet[a] = struct{}{}
-		}
-		allProbeIPs = append(allProbeIPs, ipSet)
-	}
 
-	// Verify all probes returned the same set of IPs
-	// Build the intersection of all probe results
-	intersection := allProbeIPs[0]
-	for i := 1; i < len(allProbeIPs); i++ {
-		next := make(map[string]struct{})
-		for ip := range intersection {
-			if _, ok := allProbeIPs[i][ip]; ok {
-				next[ip] = struct{}{}
+		// Also verify the union is equal to the intersection (all probes returned the same set)
+		union := make(map[string]struct{})
+		for _, probeSet := range allProbeIPs {
+			for ip := range probeSet {
+				union[ip] = struct{}{}
 			}
 		}
-		intersection = next
-	}
-
-	if len(intersection) == 0 {
-		d.nonWildcardDomains[parent] = struct{}{}
-		gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (no common IPs across probes)\n", parent)
-		return nil
-	}
-
-	// Also verify the union is equal to the intersection (all probes returned the same set)
-	union := make(map[string]struct{})
-	for _, probeSet := range allProbeIPs {
-		for ip := range probeSet {
-			union[ip] = struct{}{}
+		if len(union) != len(intersection) {
+			d.mu.Lock()
+			d.nonWildcardDomains[parent] = struct{}{}
+			d.mu.Unlock()
+			gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (inconsistent IPs across probes)\n", parent)
+			return &probeResult{nil}, nil
 		}
-	}
-	if len(union) != len(intersection) {
-		d.nonWildcardDomains[parent] = struct{}{}
-		gologger.Debug().Msgf("Auto-wildcard: %s is not wildcard (inconsistent IPs across probes)\n", parent)
-		return nil
-	}
 
-	// This parent domain is a wildcard
-	d.wildcardIPs[parent] = intersection
-	ips := make([]string, 0, len(intersection))
-	for ip := range intersection {
-		ips = append(ips, ip)
-	}
-	gologger.Verbose().Msgf("Auto-wildcard: detected %s as wildcard domain (IPs: %v)\n", parent, ips)
-	return intersection
+		// This parent domain is a wildcard — store under write lock.
+		d.mu.Lock()
+		d.wildcardIPs[parent] = intersection
+		d.mu.Unlock()
+
+		ips := make([]string, 0, len(intersection))
+		for ip := range intersection {
+			ips = append(ips, ip)
+		}
+		gologger.Verbose().Msgf("Auto-wildcard: detected %s as wildcard domain (IPs: %v)\n", parent, ips)
+		return &probeResult{intersection}, nil
+	})
+
+	return v.(*probeResult).wildcardIPs
 }

--- a/internal/runner/autowildcard_test.go
+++ b/internal/runner/autowildcard_test.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractParentDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{
+			name:     "simple subdomain",
+			host:     "sub.example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "deep subdomain",
+			host:     "a.b.c.example.com",
+			expected: "b.c.example.com",
+		},
+		{
+			name:     "bare domain returns empty",
+			host:     "example.com",
+			expected: "",
+		},
+		{
+			name:     "single label returns empty",
+			host:     "localhost",
+			expected: "",
+		},
+		{
+			name:     "trailing dot stripped",
+			host:     "sub.example.com.",
+			expected: "example.com",
+		},
+		{
+			name:     "two-level tld subdomain",
+			host:     "sub.example.co.uk",
+			expected: "example.co.uk",
+		},
+		{
+			name:     "empty string",
+			host:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractParentDomain(tt.host)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestAutoWildcardDetector_IsWildcard_EmptyRecords(t *testing.T) {
+	d := &autoWildcardDetector{
+		wildcardIPs:        make(map[string]map[string]struct{}),
+		nonWildcardDomains: make(map[string]struct{}),
+		numProbes:          3,
+	}
+	// Empty A records should not be considered wildcard
+	require.False(t, d.isWildcard("sub.example.com", nil))
+	require.False(t, d.isWildcard("sub.example.com", []string{}))
+}
+
+func TestAutoWildcardDetector_IsWildcard_NoParent(t *testing.T) {
+	d := &autoWildcardDetector{
+		wildcardIPs:        make(map[string]map[string]struct{}),
+		nonWildcardDomains: make(map[string]struct{}),
+		numProbes:          3,
+	}
+	// Bare domain with no parent should not be considered wildcard
+	require.False(t, d.isWildcard("example.com", []string{"1.2.3.4"}))
+}
+
+func TestAutoWildcardDetector_IsWildcard_KnownNonWildcard(t *testing.T) {
+	d := &autoWildcardDetector{
+		wildcardIPs:        make(map[string]map[string]struct{}),
+		nonWildcardDomains: map[string]struct{}{"example.com": {}},
+		numProbes:          3,
+	}
+	// Parent marked as non-wildcard should return false
+	require.False(t, d.isWildcard("sub.example.com", []string{"1.2.3.4"}))
+}
+
+func TestAutoWildcardDetector_IsWildcard_KnownWildcard(t *testing.T) {
+	d := &autoWildcardDetector{
+		wildcardIPs: map[string]map[string]struct{}{
+			"example.com": {"1.2.3.4": {}, "5.6.7.8": {}},
+		},
+		nonWildcardDomains: make(map[string]struct{}),
+		numProbes:          3,
+	}
+	// A records that are a subset of wildcard IPs should be filtered
+	require.True(t, d.isWildcard("sub.example.com", []string{"1.2.3.4"}))
+	require.True(t, d.isWildcard("other.example.com", []string{"1.2.3.4", "5.6.7.8"}))
+
+	// A records that include non-wildcard IPs should not be filtered
+	require.False(t, d.isWildcard("legit.example.com", []string{"9.9.9.9"}))
+	require.False(t, d.isWildcard("mixed.example.com", []string{"1.2.3.4", "9.9.9.9"}))
+}
+
+func TestAutoWildcardDetector_FilteredCount(t *testing.T) {
+	d := &autoWildcardDetector{
+		wildcardIPs: map[string]map[string]struct{}{
+			"example.com": {"1.2.3.4": {}},
+		},
+		nonWildcardDomains: make(map[string]struct{}),
+		numProbes:          3,
+	}
+	require.Equal(t, int64(0), d.filteredCount.Load())
+
+	d.isWildcard("a.example.com", []string{"1.2.3.4"})
+	require.Equal(t, int64(1), d.filteredCount.Load())
+
+	d.isWildcard("b.example.com", []string{"1.2.3.4"})
+	require.Equal(t, int64(2), d.filteredCount.Load())
+
+	// Non-matching should not increment
+	d.isWildcard("c.example.com", []string{"9.9.9.9"})
+	require.Equal(t, int64(2), d.filteredCount.Load())
+}
+
+func TestAutoWildcardDetector_DeepSubdomain(t *testing.T) {
+	d := &autoWildcardDetector{
+		wildcardIPs: map[string]map[string]struct{}{
+			"b.example.com": {"10.0.0.1": {}},
+		},
+		nonWildcardDomains: make(map[string]struct{}),
+		numProbes:          3,
+	}
+	// "a.b.example.com" has parent "b.example.com" which is wildcard
+	require.True(t, d.isWildcard("a.b.example.com", []string{"10.0.0.1"}))
+	// "x.example.com" has parent "example.com" which is not in any list, so probing needed
+	// Without a runner this would fail, but the parent "example.com" is not pre-populated so skip
+}
+
+func TestNewAutoWildcardDetector_MinProbes(t *testing.T) {
+	// numProbes below 2 should be clamped to 2
+	d := newAutoWildcardDetector(nil, 1)
+	require.Equal(t, 2, d.numProbes)
+
+	d = newAutoWildcardDetector(nil, 0)
+	require.Equal(t, 2, d.numProbes)
+
+	d = newAutoWildcardDetector(nil, 5)
+	require.Equal(t, 5, d.numProbes)
+}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -79,6 +79,8 @@ type Options struct {
 	DisableUpdateCheck    bool
 	PdcpAuth              string
 	Proxy                 string
+	AutoWildcard          bool
+	WildcardProbes        int
 }
 
 // ShouldLoadResume resume file
@@ -141,6 +143,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ResponseOnly, "resp-only", "ro", false, "display dns response only"),
 		flagSet.StringVarP(&options.RCode, "rcode", "rc", "", "filter result by dns status code (eg. -rcode noerror,servfail,refused)"),
 		flagSet.StringVarP(&options.ResponseTypeFilter, "response-type-filter", "rtf", "", "return entries with no records for the specified query types (e.g., a, cname)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatic wildcard detection and filtering"),
+		flagSet.IntVarP(&options.WildcardProbes, "wildcard-probes", "wp", 3, "number of random probes for wildcard detection (default 3)"),
 	)
 
 	flagSet.CreateGroup("probe", "Probe",
@@ -307,9 +311,16 @@ func (options *Options) validateOptions() {
 		if options.WildcardDomain != "" {
 			gologger.Fatal().Msgf("wildcard not supported in stream mode")
 		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
+		}
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")
 		}
+	}
+
+	if options.AutoWildcard && options.WildcardDomain != "" {
+		gologger.Fatal().Msgf("auto-wildcard and wildcard-domain flags cannot be used together")
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,22 +32,23 @@ import (
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
-	options             *Options
-	dnsx                *dnsx.DNSX
-	wgoutputworker      *sync.WaitGroup
-	wgresolveworkers    *sync.WaitGroup
-	wgwildcardworker    *sync.WaitGroup
-	workerchan          chan string
-	outputchan          chan string
-	wildcardworkerchan  chan string
-	wildcards           *mapsutil.SyncLockMap[string, struct{}]
-	wildcardscache      map[string][]string
-	wildcardscachemutex sync.Mutex
-	limiter             *ratelimit.Limiter
-	hm                  *hybrid.HybridMap
-	stats               clistats.StatisticsClient
-	tmpStdinFile        string
-	aurora              aurora.Aurora
+	options              *Options
+	dnsx                 *dnsx.DNSX
+	wgoutputworker       *sync.WaitGroup
+	wgresolveworkers     *sync.WaitGroup
+	wgwildcardworker     *sync.WaitGroup
+	workerchan           chan string
+	outputchan           chan string
+	wildcardworkerchan   chan string
+	wildcards            *mapsutil.SyncLockMap[string, struct{}]
+	wildcardscache       map[string][]string
+	wildcardscachemutex  sync.Mutex
+	limiter              *ratelimit.Limiter
+	hm                   *hybrid.HybridMap
+	stats                clistats.StatisticsClient
+	tmpStdinFile         string
+	aurora               aurora.Aurora
+	autoWildcardDetector *autoWildcardDetector
 }
 
 func New(options *Options) (*Runner, error) {
@@ -163,6 +164,10 @@ func New(options *Options) (*Runner, error) {
 		hm:                 hm,
 		stats:              stats,
 		aurora:             aurora.NewAurora(!options.NoColor),
+	}
+
+	if options.AutoWildcard {
+		r.autoWildcardDetector = newAutoWildcardDetector(&r, options.WildcardProbes)
 	}
 
 	return &r, nil
@@ -467,6 +472,13 @@ func (r *Runner) run() error {
 	close(r.outputchan)
 	r.wgoutputworker.Wait()
 
+	if r.autoWildcardDetector != nil {
+		filtered := r.autoWildcardDetector.filteredCount.Load()
+		if filtered > 0 {
+			gologger.Info().Msgf("Auto-wildcard: %d results filtered\n", filtered)
+		}
+	}
+
 	if r.options.WildcardDomain != "" {
 		gologger.Print().Msgf("Starting to filter wildcard subdomains\n")
 		ipDomain := make(map[string]map[string]struct{})
@@ -730,6 +742,12 @@ func (r *Runner) worker() {
 				}
 			}
 		}
+		// auto wildcard detection: filter results matching wildcard IPs
+		if r.autoWildcardDetector != nil && r.autoWildcardDetector.isWildcard(domain, dnsData.A) {
+			gologger.Debug().Msgf("Filtered wildcard result: %s\n", domain)
+			continue
+		}
+
 		// if wildcard filtering just store the data
 		if r.options.WildcardDomain != "" {
 			if err := r.storeDNSData(dnsData.DNSData); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -116,7 +116,7 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	// If no option is specified or wildcard filter has been requested use query type A
-	if len(questionTypes) == 0 || options.WildcardDomain != "" {
+	if len(questionTypes) == 0 || options.WildcardDomain != "" || options.AutoWildcard {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -680,7 +680,8 @@ func (r *Runner) worker() {
 
 		// auto wildcard detection: filter results matching wildcard IPs
 		// early, before expensive trace/AXFR/CDN/ASN lookups
-		if r.autoWildcardDetector != nil && r.autoWildcardDetector.isWildcard(domain, dnsData.A) {
+		// hosts-file results bypass the wildcard filter (they are not DNS queries)
+		if !dnsData.HostsFile && r.autoWildcardDetector != nil && r.autoWildcardDetector.isWildcard(domain, dnsData.A) {
 			gologger.Debug().Msgf("Filtered wildcard result: %s\n", domain)
 			continue
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -678,6 +678,13 @@ func (r *Runner) worker() {
 			}
 		}
 
+		// auto wildcard detection: filter results matching wildcard IPs
+		// early, before expensive trace/AXFR/CDN/ASN lookups
+		if r.autoWildcardDetector != nil && r.autoWildcardDetector.isWildcard(domain, dnsData.A) {
+			gologger.Debug().Msgf("Filtered wildcard result: %s\n", domain)
+			continue
+		}
+
 		if !r.options.Raw {
 			dnsData.Raw = ""
 		}
@@ -742,12 +749,6 @@ func (r *Runner) worker() {
 				}
 			}
 		}
-		// auto wildcard detection: filter results matching wildcard IPs
-		if r.autoWildcardDetector != nil && r.autoWildcardDetector.isWildcard(domain, dnsData.A) {
-			gologger.Debug().Msgf("Filtered wildcard result: %s\n", domain)
-			continue
-		}
-
 		// if wildcard filtering just store the data
 		if r.options.WildcardDomain != "" {
 			if err := r.storeDNSData(dnsData.DNSData); err != nil {


### PR DESCRIPTION
## Summary

Adds a new `--auto-wildcard` (`-aw`) flag that automatically detects wildcard DNS domains during resolution and filters out matching results. This implements the feature requested in #924.

## How it works

When `--auto-wildcard` is enabled, the tool lazily probes each parent domain the first time a subdomain is encountered. It sends N random subdomain queries (e.g., `<random>.example.com`) and checks whether they all resolve to the same set of IPs. If they do, the parent domain is classified as a wildcard and those IPs are stored. Any subsequent results whose A records are entirely within the wildcard IP set are silently dropped from output.

The number of probe queries is configurable via `--wildcard-probes` (`-wp`), defaulting to 3. Results from detected wildcard domains and probe statistics are available via the `-v` flag.

Parent domain detection results are cached, so each parent domain is only probed once regardless of how many subdomains are processed. The probing uses the same `xid`-based random string generation that the existing wildcard code already relies on.

## New flags

| Flag | Short | Default | Description |
|------|-------|---------|-------------|
| `--auto-wildcard` | `-aw` | false | Enable automatic wildcard detection and filtering |
| `--wildcard-probes` | `-wp` | 3 | Number of random probes per parent domain |

## Usage

```
# Basic usage with a subdomain list
cat subdomains.txt | dnsx -aw

# With custom probe count and verbose output
dnsx -l subs.txt -aw -wp 5 -v

# Works with domain bruteforce mode too
dnsx -d example.com,other.com -w wordlist.txt -aw
```

## Validation

- Mutually exclusive with `--wildcard-domain` (the existing manual wildcard mode)
- Blocked in stream mode (consistent with other wildcard/stats features)
- Minimum of 2 probes enforced to avoid false positives

## Test plan

- [x] Unit tests for `extractParentDomain` covering subdomains, bare domains, trailing dots, empty input
- [x] Unit tests for `isWildcard` with pre-populated wildcard/non-wildcard maps
- [x] Unit tests for filtered count tracking
- [x] Unit tests for minimum probe clamping
- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] All existing tests still pass

Fixes #924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic wildcard DNS detection with --auto-wildcard and configurable --wildcard-probes (minimum 2)
  * Automatically filters wildcard results during processing and logs a summary of filtered counts
  * Validation prevents use of --auto-wildcard in stream mode and with --wildcard-domain

* **Tests**
  * Added unit tests covering parent-domain extraction, probe behavior, detection logic, and filtered counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->