### PR TITLE
feat: add --auto-wildcard flag for automatic wildcard DNS detection

### DIFF
--- a/internal/runner/autowildcard.go
+++ b/internal/runner/autowildcard.go
@@ -1,0 +1,193 @@
+package runner
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/rs/xid"
+	"github.com/weppos/publicsuffix-go/publicsuffix"
+)
+
+const (
+	// autoWildcardProbes is the number of random subdomain probes per root domain
+	autoWildcardProbes = 3
+)
+
+// autoWildcardFilter holds detected wildcard IPs per root domain
+type autoWildcardFilter struct {
+	// wildcardIPs maps root domain -> set of wildcard IP addresses
+	wildcardIPs map[string]map[string]struct{}
+	mu          sync.RWMutex
+}
+
+// newAutoWildcardFilter creates a new auto wildcard filter
+func newAutoWildcardFilter() *autoWildcardFilter {
+	return &autoWildcardFilter{
+		wildcardIPs: make(map[string]map[string]struct{}),
+	}
+}
+
+// extractRootDomain extracts the root domain from a hostname using publicsuffix
+func extractRootDomain(hostname string) string {
+	hostname = strings.TrimSuffix(hostname, ".")
+	domain, err := publicsuffix.Domain(hostname)
+	if err != nil {
+		// fallback: use last two parts of the hostname
+		parts := strings.Split(hostname, ".")
+		if len(parts) >= 2 {
+			return strings.Join(parts[len(parts)-2:], ".")
+		}
+		return hostname
+	}
+	return domain
+}
+
+// detectWildcards probes root domains with random subdomains to identify wildcard DNS responses.
+// It collects all unique root domains from the input, then queries random non-existent
+// subdomains for each. IPs that consistently appear across probes are recorded as wildcard IPs.
+func (r *Runner) detectWildcards() *autoWildcardFilter {
+	awf := newAutoWildcardFilter()
+
+	// Collect unique root domains from all input hosts
+	rootDomains := make(map[string]struct{})
+	r.hm.Scan(func(k, _ []byte) error {
+		host := string(k)
+		root := extractRootDomain(host)
+		if root != "" {
+			rootDomains[root] = struct{}{}
+		}
+		return nil
+	})
+
+	if len(rootDomains) == 0 {
+		return awf
+	}
+
+	gologger.Info().Msgf("Auto-wildcard: probing %d root domain(s) for wildcard DNS", len(rootDomains))
+
+	var wg sync.WaitGroup
+	domainChan := make(chan string)
+
+	// Use up to Threads workers, but not more than number of domains
+	numWorkers := r.options.Threads
+	if numWorkers > len(rootDomains) {
+		numWorkers = len(rootDomains)
+	}
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for rootDomain := range domainChan {
+				r.probeWildcard(rootDomain, awf)
+			}
+		}()
+	}
+
+	for domain := range rootDomains {
+		domainChan <- domain
+	}
+	close(domainChan)
+	wg.Wait()
+
+	// Log findings
+	awf.mu.RLock()
+	totalWildcardDomains := 0
+	for domain, ips := range awf.wildcardIPs {
+		if len(ips) > 0 {
+			totalWildcardDomains++
+			ipList := make([]string, 0, len(ips))
+			for ip := range ips {
+				ipList = append(ipList, ip)
+			}
+			gologger.Info().Msgf("Auto-wildcard: %s is a wildcard domain (IPs: %s)", domain, strings.Join(ipList, ", "))
+		}
+	}
+	awf.mu.RUnlock()
+
+	if totalWildcardDomains > 0 {
+		gologger.Info().Msgf("Auto-wildcard: detected %d wildcard domain(s), results matching wildcard IPs will be filtered", totalWildcardDomains)
+	} else {
+		gologger.Info().Msgf("Auto-wildcard: no wildcard domains detected")
+	}
+
+	return awf
+}
+
+// probeWildcard queries random non-existent subdomains for a root domain.
+// If all probes return A records, the intersection of IPs across probes
+// is recorded as the wildcard fingerprint for that domain.
+func (r *Runner) probeWildcard(rootDomain string, awf *autoWildcardFilter) {
+	// ipCounts tracks how many probes returned each IP
+	ipCounts := make(map[string]int)
+	successfulProbes := 0
+
+	for i := 0; i < autoWildcardProbes; i++ {
+		randomSub := xid.New().String() + "." + rootDomain
+		r.limiter.Take()
+		result, err := r.dnsx.QueryOne(randomSub)
+		if err != nil || result == nil {
+			continue
+		}
+
+		if len(result.A) == 0 {
+			// No A record means this domain does not have wildcard DNS
+			return
+		}
+
+		successfulProbes++
+		for _, ip := range result.A {
+			ipCounts[ip]++
+		}
+	}
+
+	// Only mark as wildcard if we got consistent results across multiple probes
+	if successfulProbes < 2 {
+		return
+	}
+
+	// IPs that appeared in ALL successful probes are wildcard IPs
+	wildcardIPs := make(map[string]struct{})
+	for ip, count := range ipCounts {
+		if count >= successfulProbes {
+			wildcardIPs[ip] = struct{}{}
+		}
+	}
+
+	if len(wildcardIPs) > 0 {
+		awf.mu.Lock()
+		awf.wildcardIPs[rootDomain] = wildcardIPs
+		awf.mu.Unlock()
+	}
+}
+
+// isAutoWildcard checks if a DNS response matches detected wildcard IPs for its root domain.
+// Returns true if ALL of the host's A records match the wildcard IPs (meaning it's a wildcard result).
+func (awf *autoWildcardFilter) isAutoWildcard(host string, aRecords []string) bool {
+	if len(aRecords) == 0 {
+		return false
+	}
+
+	rootDomain := extractRootDomain(host)
+
+	awf.mu.RLock()
+	wildcardIPs, ok := awf.wildcardIPs[rootDomain]
+	awf.mu.RUnlock()
+
+	if !ok || len(wildcardIPs) == 0 {
+		return false
+	}
+
+	// Check if ALL A records match known wildcard IPs
+	for _, ip := range aRecords {
+		if _, isWildcard := wildcardIPs[ip]; !isWildcard {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/runner/autowildcard_test.go
+++ b/internal/runner/autowildcard_test.go
@@ -1,0 +1,128 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractRootDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple subdomain",
+			input:    "foo.example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "deep subdomain",
+			input:    "a.b.c.example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "root domain only",
+			input:    "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "co.uk domain",
+			input:    "sub.example.co.uk",
+			expected: "example.co.uk",
+		},
+		{
+			name:     "trailing dot",
+			input:    "foo.example.com.",
+			expected: "example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRootDomain(tt.input)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestAutoWildcardFilter_isAutoWildcard(t *testing.T) {
+	awf := newAutoWildcardFilter()
+
+	// Set up wildcard IPs for example.com
+	awf.wildcardIPs["example.com"] = map[string]struct{}{
+		"1.2.3.4": {},
+		"5.6.7.8": {},
+	}
+
+	tests := []struct {
+		name     string
+		host     string
+		aRecords []string
+		expected bool
+	}{
+		{
+			name:     "all records match wildcard",
+			host:     "test.example.com",
+			aRecords: []string{"1.2.3.4"},
+			expected: true,
+		},
+		{
+			name:     "multiple records all match wildcard",
+			host:     "test.example.com",
+			aRecords: []string{"1.2.3.4", "5.6.7.8"},
+			expected: true,
+		},
+		{
+			name:     "some records do not match wildcard",
+			host:     "test.example.com",
+			aRecords: []string{"1.2.3.4", "9.9.9.9"},
+			expected: false,
+		},
+		{
+			name:     "no records match wildcard",
+			host:     "test.example.com",
+			aRecords: []string{"9.9.9.9"},
+			expected: false,
+		},
+		{
+			name:     "empty A records",
+			host:     "test.example.com",
+			aRecords: []string{},
+			expected: false,
+		},
+		{
+			name:     "nil A records",
+			host:     "test.example.com",
+			aRecords: nil,
+			expected: false,
+		},
+		{
+			name:     "domain without wildcard",
+			host:     "test.other.com",
+			aRecords: []string{"1.2.3.4"},
+			expected: false,
+		},
+		{
+			name:     "deep subdomain matches wildcard",
+			host:     "a.b.c.example.com",
+			aRecords: []string{"1.2.3.4"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := awf.isAutoWildcard(tt.host, tt.aRecords)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNewAutoWildcardFilter(t *testing.T) {
+	awf := newAutoWildcardFilter()
+	require.NotNil(t, awf)
+	require.NotNil(t, awf.wildcardIPs)
+	require.Empty(t, awf.wildcardIPs)
+}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -79,6 +79,7 @@ type Options struct {
 	DisableUpdateCheck    bool
 	PdcpAuth              string
 	Proxy                 string
+	AutoWildcard          bool
 }
 
 // ShouldLoadResume resume file
@@ -141,6 +142,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ResponseOnly, "resp-only", "ro", false, "display dns response only"),
 		flagSet.StringVarP(&options.RCode, "rcode", "rc", "", "filter result by dns status code (eg. -rcode noerror,servfail,refused)"),
 		flagSet.StringVarP(&options.ResponseTypeFilter, "response-type-filter", "rtf", "", "return entries with no records for the specified query types (e.g., a, cname)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatic wildcard detection and filtering"),
 	)
 
 	flagSet.CreateGroup("probe", "Probe",
@@ -294,6 +296,10 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("stdin can be set for one flag")
 	}
 
+	if options.AutoWildcard && options.WildcardDomain != "" {
+		gologger.Fatal().Msgf("auto-wildcard and wildcard-domain can't be used at the same time")
+	}
+
 	if options.Stream {
 		if wordListPresent {
 			gologger.Fatal().Msgf("wordlist not supported in stream mode")
@@ -306,6 +312,9 @@ func (options *Options) validateOptions() {
 		}
 		if options.WildcardDomain != "" {
 			gologger.Fatal().Msgf("wildcard not supported in stream mode")
+		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
 		}
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -48,6 +48,7 @@ type Runner struct {
 	stats               clistats.StatisticsClient
 	tmpStdinFile        string
 	aurora              aurora.Aurora
+	awFilter            *autoWildcardFilter
 }
 
 func New(options *Options) (*Runner, error) {
@@ -454,6 +455,11 @@ func (r *Runner) run() error {
 		gologger.Debug().Msgf("Resuming scan using file %s. Restarting at position %d: %s\n", DefaultResumeFile, r.options.resumeCfg.Index, r.options.resumeCfg.ResumeFrom)
 	}
 
+	// Perform auto wildcard detection before starting the scan
+	if r.options.AutoWildcard {
+		r.awFilter = r.detectWildcards()
+	}
+
 	r.startWorkers()
 
 	r.wgresolveworkers.Wait()
@@ -664,6 +670,11 @@ func (r *Runner) worker() {
 					continue
 				}
 			}
+		}
+
+		// Auto-wildcard filtering: skip results that match detected wildcard IPs
+		if r.options.AutoWildcard && r.awFilter != nil && r.awFilter.isAutoWildcard(domain, dnsData.A) {
+			continue
 		}
 
 		if !r.options.Raw {


### PR DESCRIPTION
## Summary

- Adds `--auto-wildcard` / `-aw` flag that automatically detects wildcard DNS domains and filters matching results, similar to PureDNS
- Before scanning, probes each unique root domain (extracted via `publicsuffix`) with multiple random non-existent subdomains to fingerprint wildcard IPs
- During the scan, filters out results where all A records match detected wildcard IPs for that root domain
- Works across multiple domains in a single run without requiring per-domain `--wildcard-domain` configuration

## How It Works

1. **Root domain extraction**: Uses the `publicsuffix` library (already a dependency) to extract root domains from all input hosts
2. **Wildcard probing**: For each root domain, queries 3 random non-existent subdomains (e.g., `<xid>.example.com`)
3. **Fingerprinting**: IPs that appear consistently across all successful probes are recorded as wildcard IPs
4. **Filtering**: During the main scan, any result whose A records all match wildcard IPs is silently filtered out

## Usage

```bash
# Basic usage - auto-detect and filter wildcards
echo "sub1.example.com\nsub2.example.com" | dnsx --auto-wildcard

# With bruteforce mode
dnsx -d example.com -w wordlist.txt --auto-wildcard

# Combined with other flags
dnsx -l hosts.txt --auto-wildcard -resp -a
```

## Proof

Unit tests covering core logic (root domain extraction, wildcard IP matching):

```
=== RUN   TestExtractRootDomain
=== RUN   TestExtractRootDomain/simple_subdomain
=== RUN   TestExtractRootDomain/deep_subdomain
=== RUN   TestExtractRootDomain/root_domain_only
=== RUN   TestExtractRootDomain/co.uk_domain
=== RUN   TestExtractRootDomain/trailing_dot
--- PASS: TestExtractRootDomain (0.00s)
=== RUN   TestAutoWildcardFilter_isAutoWildcard
=== RUN   TestAutoWildcardFilter_isAutoWildcard/all_records_match_wildcard
=== RUN   TestAutoWildcardFilter_isAutoWildcard/multiple_records_all_match_wildcard
=== RUN   TestAutoWildcardFilter_isAutoWildcard/some_records_do_not_match_wildcard
=== RUN   TestAutoWildcardFilter_isAutoWildcard/no_records_match_wildcard
=== RUN   TestAutoWildcardFilter_isAutoWildcard/empty_A_records
=== RUN   TestAutoWildcardFilter_isAutoWildcard/nil_A_records
=== RUN   TestAutoWildcardFilter_isAutoWildcard/domain_without_wildcard
=== RUN   TestAutoWildcardFilter_isAutoWildcard/deep_subdomain_matches_wildcard
--- PASS: TestAutoWildcardFilter_isAutoWildcard (0.00s)
=== RUN   TestNewAutoWildcardFilter
--- PASS: TestNewAutoWildcardFilter (0.00s)
PASS
```

Build verification:
```
$ go build ./...   # No errors
$ go vet ./...     # No warnings
```

## Checklist

- [x] PR created against the correct branch (`dev`)
- [x] All checks passed (build, vet, unit tests)
- [x] Tests added that prove the feature works
- [x] No breaking changes to existing functionality

/claim #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --auto-wildcard flag to auto-detect and filter wildcard DNS responses before a scan; matching results are excluded from output.

* **Changes**
  * --auto-wildcard cannot be used with explicit wildcard-domain option and is not supported in stream mode; error messages reflect these restrictions.

* **Tests**
  * Added unit tests covering root-domain extraction and auto-wildcard detection/filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->