### PR TITLE
Add automatic wildcard DNS detection and filtering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/projectdiscovery/utils v0.7.3
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.47.0
 )
 
 require (
@@ -120,7 +121,6 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	TraceMaxRecursion     int
 	WildcardThreshold     int
 	WildcardDomain        string
+	AutoWildcard          bool
 	ShowStatistics        bool
 	rcodes                map[int]struct{}
 	RCode                 string
@@ -189,6 +190,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "enable automatic wildcard detection and filtering"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "proxy to use (eg socks5://127.0.0.1:8080)"),
 	)
 
@@ -294,6 +296,10 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("stdin can be set for one flag")
 	}
 
+	if options.AutoWildcard && options.WildcardDomain != "" {
+		gologger.Fatal().Msgf("auto-wildcard and wildcard-domain flags can't be used at the same time")
+	}
+
 	if options.Stream {
 		if wordListPresent {
 			gologger.Fatal().Msgf("wordlist not supported in stream mode")
@@ -306,6 +312,9 @@ func (options *Options) validateOptions() {
 		}
 		if options.WildcardDomain != "" {
 			gologger.Fatal().Msgf("wildcard not supported in stream mode")
+		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
 		}
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/logrusorgru/aurora"
@@ -17,6 +18,7 @@ import (
 	asnmap "github.com/projectdiscovery/asnmap/libs"
 	"github.com/projectdiscovery/clistats"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/dnsx/pkg/wildcards"
 	"github.com/projectdiscovery/goconfig"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/hmap/store/hybrid"
@@ -28,6 +30,7 @@ import (
 	iputil "github.com/projectdiscovery/utils/ip"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 	sliceutil "github.com/projectdiscovery/utils/slice"
+	"golang.org/x/net/publicsuffix"
 )
 
 // Runner is a client for running the enumeration process.
@@ -48,6 +51,11 @@ type Runner struct {
 	stats               clistats.StatisticsClient
 	tmpStdinFile        string
 	aurora              aurora.Aurora
+
+	// auto-wildcard fields
+	wildcardResolver      *wildcards.Resolver
+	autoWildcardDomains   []string
+	wildcardFilteredCount atomic.Int64
 }
 
 func New(options *Options) (*Runner, error) {
@@ -115,9 +123,11 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	// If no option is specified or wildcard filter has been requested use query type A
-	if len(questionTypes) == 0 || options.WildcardDomain != "" {
+	if len(questionTypes) == 0 || options.WildcardDomain != "" || options.AutoWildcard {
+		if !options.A {
+			questionTypes = append(questionTypes, dns.TypeA)
+		}
 		options.A = true
-		questionTypes = append(questionTypes, dns.TypeA)
 	}
 	dnsxOptions.QuestionTypes = questionTypes
 	dnsxOptions.QueryAll = options.QueryAll
@@ -279,8 +289,20 @@ func (r *Runner) prepareInput() error {
 	}
 
 	numHosts := 0
+	// Collect domains for auto-wildcard detection during input processing
+	var awDomainSet map[string]struct{}
+	if r.options.AutoWildcard {
+		awDomainSet = make(map[string]struct{})
+	}
 	for item := range sc {
 		item := normalize(item)
+
+		// Capture root domains for auto-wildcard
+		if r.options.AutoWildcard && r.options.Domains != "" {
+			// In bruteforce mode, item is the root domain
+			awDomainSet[item] = struct{}{}
+		}
+
 		var hosts []string
 		switch {
 		case strings.Contains(item, "FUZZ"):
@@ -320,6 +342,31 @@ func (r *Runner) prepareInput() error {
 		default:
 			hosts = []string{item}
 			numHosts += r.addHostsToHMapFromList(hosts)
+		}
+	}
+
+	// For auto-wildcard in list mode (-l), extract root domains from hosts
+	if r.options.AutoWildcard && r.options.Domains == "" {
+		if awDomainSet == nil {
+			awDomainSet = make(map[string]struct{})
+		}
+		r.hm.Scan(func(k, _ []byte) error {
+			host := string(k)
+			if iputil.IsIP(host) {
+				return nil
+			}
+			domain, err := publicsuffix.EffectiveTLDPlusOne(host)
+			if err == nil && domain != "" {
+				awDomainSet[domain] = struct{}{}
+			}
+			return nil
+		})
+	}
+
+	// Store collected auto-wildcard domains
+	if r.options.AutoWildcard && len(awDomainSet) > 0 {
+		for d := range awDomainSet {
+			r.autoWildcardDomains = append(r.autoWildcardDomains, d)
 		}
 	}
 	if r.options.ShowStatistics {
@@ -449,6 +496,28 @@ func (r *Runner) run() error {
 		return err
 	}
 
+	// Setup auto-wildcard resolver after input preparation
+	if r.options.AutoWildcard {
+		if len(r.autoWildcardDomains) > 0 {
+			gologger.Info().Msgf("Auto-wildcard detection enabled for %d domain(s): %s\n",
+				len(r.autoWildcardDomains), strings.Join(r.autoWildcardDomains, ", "))
+
+			wcOptions := dnsx.DefaultOptions
+			wcOptions.BaseResolvers = r.dnsx.Options.BaseResolvers
+			wcOptions.MaxRetries = r.options.Retries
+			wcOptions.Timeout = r.options.Timeout
+			wcOptions.Proxy = r.options.Proxy
+
+			wcClient, err := dnsx.New(wcOptions)
+			if err != nil {
+				return fmt.Errorf("could not create wildcard resolver: %w", err)
+			}
+			r.wildcardResolver = wildcards.NewResolverWithClient(r.autoWildcardDomains, wcClient)
+		} else {
+			gologger.Warning().Msg("Auto-wildcard: no domains detected, wildcard filtering disabled\n")
+		}
+	}
+
 	// if resume is enabled inform the user
 	if r.options.ShouldLoadResume() && r.options.resumeCfg.Index > 0 {
 		gologger.Debug().Msgf("Resuming scan using file %s. Restarting at position %d: %s\n", DefaultResumeFile, r.options.resumeCfg.Index, r.options.resumeCfg.ResumeFrom)
@@ -546,6 +615,13 @@ func (r *Runner) run() error {
 		// waiting output worker
 		r.wgoutputworker.Wait()
 		gologger.Print().Msgf("%d wildcard subdomains removed\n", numRemovedSubdomains)
+	}
+
+	// Log auto-wildcard stats
+	if r.options.AutoWildcard {
+		if count := r.wildcardFilteredCount.Load(); count > 0 {
+			gologger.Info().Msgf("%d wildcard subdomains filtered\n", count)
+		}
 	}
 
 	return nil
@@ -730,6 +806,14 @@ func (r *Runner) worker() {
 				}
 			}
 		}
+		// Auto-wildcard inline filtering
+		if r.options.AutoWildcard && r.wildcardResolver != nil {
+			if r.isAutoWildcard(domain, &dnsData) {
+				r.wildcardFilteredCount.Add(1)
+				continue
+			}
+		}
+
 		// if wildcard filtering just store the data
 		if r.options.WildcardDomain != "" {
 			if err := r.storeDNSData(dnsData.DNSData); err != nil {
@@ -944,4 +1028,17 @@ func (r *Runner) wildcardWorker() {
 			_ = r.wildcards.Set(host, struct{}{})
 		}
 	}
+}
+
+// isAutoWildcard checks if a host is a wildcard using the auto-wildcard resolver
+func (r *Runner) isAutoWildcard(host string, dnsData *dnsx.ResponseData) bool {
+	if dnsData.DNSData == nil || len(dnsData.A) == 0 {
+		return false
+	}
+	for _, ip := range dnsData.A {
+		if isWildcard, _ := r.wildcardResolver.LookupHost(host, ip); isWildcard {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/wildcards/resolver.go
+++ b/pkg/wildcards/resolver.go
@@ -1,0 +1,211 @@
+package wildcards
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/miekg/dns"
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/gologger"
+	mapsutil "github.com/projectdiscovery/utils/maps"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+	stringsutil "github.com/projectdiscovery/utils/strings"
+	"github.com/rs/xid"
+)
+
+// Resolver represents a dns resolver for removing wildcards
+type Resolver struct {
+	Domains *sliceutil.SyncSlice[string]
+	client  *dnsx.DNSX
+
+	levelAnswersNormalCache *mapsutil.SyncLockMap[string, struct{}]
+	wildcardAnswersCache    *mapsutil.SyncLockMap[string, wildcardAnswerCacheValue]
+}
+
+type wildcardAnswerCacheValue struct {
+	IPS *mapsutil.SyncLockMap[string, struct{}]
+}
+
+// NewResolver initializes and creates a new resolver to find wildcards
+func NewResolver(domains []string, retries int, resolvers []string) (*Resolver, error) {
+	fqdns := sliceutil.NewSyncSlice[string]()
+	fqdns.Append(domains...)
+	resolver := &Resolver{
+		Domains:                 fqdns,
+		levelAnswersNormalCache: mapsutil.NewSyncLockMap[string, struct{}](),
+		wildcardAnswersCache:    mapsutil.NewSyncLockMap[string, wildcardAnswerCacheValue](),
+	}
+
+	options := dnsx.DefaultOptions
+	options.BaseResolvers = resolvers
+	options.MaxRetries = retries
+	dnsResolver, err := dnsx.New(options)
+	if err != nil {
+		return nil, fmt.Errorf("could not create dns resolver: %w", err)
+	}
+	resolver.client = dnsResolver
+
+	return resolver, nil
+}
+
+// NewResolverWithClient creates a new wildcard resolver using an existing DNSX client
+func NewResolverWithClient(domains []string, client *dnsx.DNSX) *Resolver {
+	fqdns := sliceutil.NewSyncSlice[string]()
+	fqdns.Append(domains...)
+	return &Resolver{
+		Domains:                 fqdns,
+		client:                  client,
+		levelAnswersNormalCache: mapsutil.NewSyncLockMap[string, struct{}](),
+		wildcardAnswersCache:    mapsutil.NewSyncLockMap[string, wildcardAnswerCacheValue](),
+	}
+}
+
+// generateWildcardPermutations generates wildcard permutations for a given subdomain
+// and domain. It generates permutations for each level of the subdomain
+// in reverse order.
+func generateWildcardPermutations(subdomain, domain string) []string {
+	var hosts []string
+	subdomainTokens := strings.Split(subdomain, ".")
+
+	var builder strings.Builder
+	builder.Grow(len(subdomain) + len(domain) + 5)
+
+	// Iterate from the reverse order. This way we generate the roots
+	// first and allows us to do filtering faster, by trying out the root
+	// like *.example.com first, and *.child.example.com in that order.
+	// If we get matches for the root, we can skip the child and rest
+	builder.WriteString("*.")
+	builder.WriteString(domain)
+	hosts = append(hosts, builder.String())
+	builder.Reset()
+
+	for i := len(subdomainTokens); i > 1; i-- {
+		_, _ = builder.WriteString("*.")
+		_, _ = builder.WriteString(strings.Join(subdomainTokens[i-1:], "."))
+		_, _ = builder.WriteRune('.')
+		_, _ = builder.WriteString(domain)
+		hosts = append(hosts, builder.String())
+		builder.Reset()
+	}
+	return hosts
+}
+
+func getSyncLockMapValues(m *mapsutil.SyncLockMap[string, struct{}]) map[string]struct{} {
+	values := make(map[string]struct{})
+	_ = m.Iterate(func(key string, value struct{}) error {
+		values[key] = value
+		return nil
+	})
+	return values
+}
+
+// LookupHost returns wildcard IP addresses of a wildcard if it's a wildcard.
+// To determine, first we split the target host by dots, create permutation
+// of it's levels, check for wildcard on each one of them and if found any,
+// we remove all the hosts that have this IP from the map.
+func (w *Resolver) LookupHost(host string, ip string) (bool, map[string]struct{}) {
+	wildcards := make(map[string]struct{})
+
+	var domain string
+	w.Domains.Each(func(i int, domainCandidate string) error {
+		if stringsutil.HasSuffixAny(host, "."+domainCandidate) {
+			domain = domainCandidate
+			// just to interrupt the iteration
+			return errors.New("found domain")
+		}
+		return nil
+	})
+
+	// ignore records without domain (todo: might be interesting to detect dangling domains)
+	if domain == "" {
+		gologger.Info().Msgf("no domain found - skipping: %s", host)
+		return false, nil
+	}
+
+	subdomainPart := strings.TrimSuffix(host, "."+domain)
+
+	// create the wildcard generation prefix.
+	// We use a rand prefix at the beginning like %rand%.domain.tld
+	// A permutation is generated for each level of the subdomain.
+	hosts := generateWildcardPermutations(subdomainPart, domain)
+
+	// Iterate over all the hosts generated for rand.
+	for _, h := range hosts {
+		h = strings.TrimSuffix(h, ".")
+
+		original := h
+
+		// Check if we have already resolved this host level successfully
+		// and if so, use the cached answer
+		//
+		// ex. *.campaigns.google.com is a wildcard so we cache it
+		// and it is used always for resolutions in future.
+		cachedValue, cachedValueOk := w.wildcardAnswersCache.Get(original)
+		if cachedValueOk {
+			if _, ipExists := cachedValue.IPS.Get(ip); ipExists {
+				return true, getSyncLockMapValues(cachedValue.IPS)
+			}
+		}
+
+		// Check if this level provides a normal response
+		// ex. *.google.com which is not a wildcard and returns NXDOMAIN
+		if _, ok := w.levelAnswersNormalCache.Get(original); ok {
+			continue
+		}
+
+		h = strings.ReplaceAll(h, "*.", xid.New().String()+".")
+
+		// Create a dns message and send it to the server
+		in, err := w.client.QueryOne(h)
+		if err != nil {
+			continue
+		}
+		// Store this as well to be used for caching other levels
+		// so lookups don't happen as frequently.
+		// Skip the current host since we can't resolve it
+		if in != nil && in.StatusCodeRaw != dns.RcodeSuccess {
+			_ = w.levelAnswersNormalCache.Set(original, struct{}{})
+			continue
+		}
+
+		// Get all the records and add them to the wildcard map
+		for _, record := range in.A {
+			if _, ok := wildcards[record]; !ok {
+				wildcards[record] = struct{}{}
+			}
+		}
+
+		if !cachedValueOk {
+			cachedValue.IPS = mapsutil.NewSyncLockMap[string, struct{}]()
+		}
+		for _, record := range in.A {
+			_ = cachedValue.IPS.Set(record, struct{}{})
+		}
+		_ = w.wildcardAnswersCache.Set(original, cachedValue)
+		if _, ipExists := cachedValue.IPS.Get(ip); ipExists {
+			return true, getSyncLockMapValues(cachedValue.IPS)
+		}
+	}
+
+	// check if original ip are among wildcards
+	if _, ok := wildcards[ip]; ok {
+		return true, wildcards
+	}
+
+	return false, wildcards
+}
+
+func (w *Resolver) GetAllWildcardIPs() map[string]struct{} {
+	ips := make(map[string]struct{})
+
+	_ = w.wildcardAnswersCache.Iterate(func(key string, value wildcardAnswerCacheValue) error {
+		for ip := range value.IPS.Map {
+			if _, ok := ips[ip]; !ok {
+				ips[ip] = struct{}{}
+			}
+		}
+		return nil
+	})
+	return ips
+}

--- a/pkg/wildcards/resolver.go
+++ b/pkg/wildcards/resolver.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/miekg/dns"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
@@ -21,6 +22,7 @@ type Resolver struct {
 
 	levelAnswersNormalCache *mapsutil.SyncLockMap[string, struct{}]
 	wildcardAnswersCache    *mapsutil.SyncLockMap[string, wildcardAnswerCacheValue]
+	cacheMu                 sync.Mutex
 }
 
 type wildcardAnswerCacheValue struct {
@@ -176,6 +178,9 @@ func (w *Resolver) LookupHost(host string, ip string) (bool, map[string]struct{}
 			}
 		}
 
+		// Lock to prevent TOCTOU race when multiple goroutines probe the same wildcard level
+		w.cacheMu.Lock()
+		cachedValue, cachedValueOk = w.wildcardAnswersCache.Get(original)
 		if !cachedValueOk {
 			cachedValue.IPS = mapsutil.NewSyncLockMap[string, struct{}]()
 		}
@@ -183,6 +188,8 @@ func (w *Resolver) LookupHost(host string, ip string) (bool, map[string]struct{}
 			_ = cachedValue.IPS.Set(record, struct{}{})
 		}
 		_ = w.wildcardAnswersCache.Set(original, cachedValue)
+		w.cacheMu.Unlock()
+
 		if _, ipExists := cachedValue.IPS.Get(ip); ipExists {
 			return true, getSyncLockMapValues(cachedValue.IPS)
 		}
@@ -200,10 +207,8 @@ func (w *Resolver) GetAllWildcardIPs() map[string]struct{} {
 	ips := make(map[string]struct{})
 
 	_ = w.wildcardAnswersCache.Iterate(func(key string, value wildcardAnswerCacheValue) error {
-		for ip := range value.IPS.Map {
-			if _, ok := ips[ip]; !ok {
-				ips[ip] = struct{}{}
-			}
+		for ip := range getSyncLockMapValues(value.IPS) {
+			ips[ip] = struct{}{}
 		}
 		return nil
 	})

--- a/pkg/wildcards/resolver_test.go
+++ b/pkg/wildcards/resolver_test.go
@@ -1,0 +1,67 @@
+package wildcards
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_generateWildcardPermutations(t *testing.T) {
+	var tests = []struct {
+		subdomain string
+		domain    string
+		expected  []string
+	}{
+		{"test", "example.com", []string{"*.example.com"}},
+		{"abc.test", "example.com", []string{"*.example.com", "*.test.example.com"}},
+		{"xyz.abc.test", "example.com", []string{"*.example.com", "*.test.example.com", "*.abc.test.example.com"}},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s.%s", test.subdomain, test.domain), func(t *testing.T) {
+			result := generateWildcardPermutations(test.subdomain, test.domain)
+			if len(result) != len(test.expected) {
+				t.Fatalf("expected %d permutations, got %d", len(test.expected), len(result))
+			}
+			for i, r := range result {
+				if r != test.expected[i] {
+					t.Fatalf("expected %s, got %s", test.expected[i], r)
+				}
+			}
+		})
+	}
+}
+
+func Test_Resolver_LookupHost(t *testing.T) {
+	resolver, err := NewResolver([]string{"google.com"}, 3, []string{
+		"8.8.8.8",
+	})
+	require.NoError(t, err)
+
+	lookupAndResolve := func(subdomain string, r *Resolver) (bool, map[string]struct{}) {
+		ips, err := r.client.Lookup(subdomain)
+		require.NoError(t, err)
+		require.NotEmpty(t, ips)
+
+		return resolver.LookupHost(subdomain, ips[0])
+	}
+	t.Run("normal", func(t *testing.T) {
+		isWildcard, wildcards := lookupAndResolve("www.google.com", resolver)
+		require.False(t, isWildcard)
+		require.Empty(t, wildcards)
+	})
+
+	t.Run("wildcard-root-domain", func(t *testing.T) {
+		isWildcard, wildcards := lookupAndResolve("campaigns.google.com", resolver)
+		require.False(t, isWildcard)
+		require.Empty(t, wildcards)
+	})
+
+	t.Run("wildcard", func(t *testing.T) {
+		isWildcard, wildcards := lookupAndResolve(xid.New().String()+".campaigns.google.com", resolver)
+		require.True(t, isWildcard)
+		require.NotEmpty(t, wildcards)
+		fmt.Printf("wildcards: %v\n", wildcards)
+	})
+}

--- a/pkg/wildcards/store.go
+++ b/pkg/wildcards/store.go
@@ -1,0 +1,88 @@
+package wildcards
+
+import (
+	"bufio"
+	"errors"
+	"os"
+
+	mapsutil "github.com/projectdiscovery/utils/maps"
+)
+
+type Store struct {
+	wildcards *mapsutil.SyncLockMap[string, struct{}]
+}
+
+func NewStore() *Store {
+	m := mapsutil.NewSyncLockMap[string, struct{}]()
+	return &Store{wildcards: m}
+}
+
+func (s *Store) Set(wildcard string) error {
+	return s.wildcards.Set(wildcard, struct{}{})
+}
+
+func (s *Store) Has(wildcard string) bool {
+	return s.wildcards.Has(wildcard)
+}
+
+func (s *Store) Delete(wildcard string) {
+	s.wildcards.Delete(wildcard)
+}
+
+func (s *Store) Clear() {
+	s.wildcards.Clear()
+}
+
+func (s *Store) Iterate(f func(wildcard string) error) error {
+	return s.wildcards.Iterate(func(k string, v struct{}) error {
+		return f(k)
+	})
+}
+
+func (s *Store) IsEmpty() bool {
+	return s.wildcards.IsEmpty()
+}
+
+func (s *Store) SaveToFile(file string) error {
+	if s.wildcards.IsEmpty() {
+		return errors.New("no wildcards")
+	}
+
+	f, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	bw := bufio.NewWriter(f)
+	err = s.Iterate(func(k string) error {
+		_, err := bw.WriteString(k + "\n")
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	return bw.Flush()
+}
+
+func (s *Store) LoadFromFile(file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		item := scanner.Text()
+		if err := s.wildcards.Set(item, struct{}{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/wildcards/util.go
+++ b/pkg/wildcards/util.go
@@ -1,0 +1,27 @@
+package wildcards
+
+import (
+	"bufio"
+	"os"
+)
+
+func LoadResolversFromFile(file string) ([]string, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var servers []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		text := scanner.Text()
+		if text == "" {
+			continue
+		}
+		servers = append(servers, text+":53")
+	}
+	return servers, nil
+}


### PR DESCRIPTION
fixes #924
/claim #924 

## Proposed changes

Instead of re-implementing wildcard logic, this imports and extends the stable wildcard resolver from 
https://github.com/projectdiscovery/shuffledns/tree/dev/pkg/wildcards into pkg/wildcards/.

When enabled:
- Root domains are auto-detected from input (from -d flag in bruteforce mode, or extracted via public suffix list in -l list mode)
- Each resolved host is checked inline during resolution — random subdomain queries are used to detect
 wildcard IPs, with caching for performance
- Wildcard matches are silently filtered from output
- Works with all output modes (plain, -json, -resp, etc.)
- Mutually exclusive with the existing -wd flag; not supported in stream mode

## Checklist

- [x] Pull request is created against the dev branch        
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an --auto-wildcard (-aw) option to auto-detect and filter wildcard DNS responses, skipping wildcard subdomains during scans.
  * Auto-wildcard is incompatible with existing wildcard-domain options and is disabled in stream mode to avoid conflicts.
  * Wildcard detection now reports filtered counts and persists wildcard data to/from a file for reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->