### PR TITLE
feat: add automatic wildcard DNS detection and filtering

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -75,6 +75,7 @@ type Options struct {
 	ExcludeType           []string
 	OutputCDN             bool
 	ASN                   bool
+	AutoWildcard          bool
 	HealthCheck           bool
 	DisableUpdateCheck    bool
 	PdcpAuth              string
@@ -189,6 +190,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatic wildcard detection and filtering across all domains"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "proxy to use (eg socks5://127.0.0.1:8080)"),
 	)
 
@@ -267,6 +269,10 @@ func (options *Options) validateOptions() {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
 	}
 
+	if options.AutoWildcard && options.WildcardDomain != "" {
+		gologger.Fatal().Msgf("auto-wildcard and wildcard-domain can't be used at the same time")
+	}
+
 	if options.Retries == 0 {
 		gologger.Fatal().Msgf("retries must be at least 1")
 	}
@@ -306,6 +312,9 @@ func (options *Options) validateOptions() {
 		}
 		if options.WildcardDomain != "" {
 			gologger.Fatal().Msgf("wildcard not supported in stream mode")
+		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
 		}
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -686,8 +686,13 @@ func (r *Runner) worker() {
 
 		// auto wildcard filtering: skip hosts whose A records match wildcard IPs
 		if r.autoWildcardDetector != nil && len(dnsData.A) > 0 {
-			if r.autoWildcardDetector.isWildcardMatch(domain, dnsData.A) {
-				gologger.Verbose().Msgf("Wildcard filtered: %s\n", domain)
+			// use canonical host value for matching to avoid mismatches
+			hostForMatch := dnsData.Host
+			if hostForMatch == "" {
+				hostForMatch = domain
+			}
+			if r.autoWildcardDetector.isWildcardMatch(hostForMatch, dnsData.A) {
+				gologger.Verbose().Msgf("Wildcard filtered: %s\n", hostForMatch)
 				continue
 			}
 		}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -115,7 +115,7 @@ func New(options *Options) (*Runner, error) {
 		questionTypes = append(questionTypes, dns.TypeCAA)
 	}
 
-	// If no option is specified or wildcard filter has been requested use query type A
+	// Default to A query type when no option is specified
 	if len(questionTypes) == 0 {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,22 +32,23 @@ import (
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
-	options             *Options
-	dnsx                *dnsx.DNSX
-	wgoutputworker      *sync.WaitGroup
-	wgresolveworkers    *sync.WaitGroup
-	wgwildcardworker    *sync.WaitGroup
-	workerchan          chan string
-	outputchan          chan string
-	wildcardworkerchan  chan string
-	wildcards           *mapsutil.SyncLockMap[string, struct{}]
-	wildcardscache      map[string][]string
-	wildcardscachemutex sync.Mutex
-	limiter             *ratelimit.Limiter
-	hm                  *hybrid.HybridMap
-	stats               clistats.StatisticsClient
-	tmpStdinFile        string
-	aurora              aurora.Aurora
+	options              *Options
+	dnsx                 *dnsx.DNSX
+	wgoutputworker       *sync.WaitGroup
+	wgresolveworkers     *sync.WaitGroup
+	wgwildcardworker     *sync.WaitGroup
+	workerchan           chan string
+	outputchan           chan string
+	wildcardworkerchan   chan string
+	wildcards            *mapsutil.SyncLockMap[string, struct{}]
+	wildcardscache       map[string][]string
+	wildcardscachemutex  sync.Mutex
+	autoWildcardDetector *autoWildcardDetector
+	limiter              *ratelimit.Limiter
+	hm                   *hybrid.HybridMap
+	stats                clistats.StatisticsClient
+	tmpStdinFile         string
+	aurora               aurora.Aurora
 }
 
 func New(options *Options) (*Runner, error) {
@@ -115,7 +116,7 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	// If no option is specified or wildcard filter has been requested use query type A
-	if len(questionTypes) == 0 || options.WildcardDomain != "" {
+	if len(questionTypes) == 0 || options.WildcardDomain != "" || options.AutoWildcard {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)
 	}
@@ -163,6 +164,10 @@ func New(options *Options) (*Runner, error) {
 		hm:                 hm,
 		stats:              stats,
 		aurora:             aurora.NewAurora(!options.NoColor),
+	}
+
+	if options.AutoWildcard {
+		r.autoWildcardDetector = newAutoWildcardDetector(&r)
 	}
 
 	return &r, nil
@@ -663,6 +668,14 @@ func (r *Runner) worker() {
 				if _, ok := r.options.rcodes[dnsData.StatusCodeRaw]; !ok {
 					continue
 				}
+			}
+		}
+
+		// auto wildcard filtering: skip hosts whose A records match wildcard IPs
+		if r.autoWildcardDetector != nil && len(dnsData.A) > 0 {
+			if r.autoWildcardDetector.isWildcardMatch(domain, dnsData.A) {
+				gologger.Verbose().Msgf("Wildcard filtered: %s\n", domain)
+				continue
 			}
 		}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -116,9 +116,22 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	// If no option is specified or wildcard filter has been requested use query type A
-	if len(questionTypes) == 0 || options.WildcardDomain != "" || options.AutoWildcard {
+	if len(questionTypes) == 0 {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)
+	}
+	// Wildcard filtering needs A answers internally, but should not force A output.
+	if options.WildcardDomain != "" || options.AutoWildcard {
+		hasA := false
+		for _, qt := range questionTypes {
+			if qt == dns.TypeA {
+				hasA = true
+				break
+			}
+		}
+		if !hasA {
+			questionTypes = append(questionTypes, dns.TypeA)
+		}
 	}
 	dnsxOptions.QuestionTypes = questionTypes
 	dnsxOptions.QueryAll = options.QueryAll

--- a/internal/runner/wildcard.go
+++ b/internal/runner/wildcard.go
@@ -2,11 +2,141 @@ package runner
 
 import (
 	"strings"
+	"sync"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/rs/xid"
 )
 
-// IsWildcard checks if a host is wildcard
+const (
+	// autoWildcardProbes is the number of random subdomain probes for auto detection
+	autoWildcardProbes = 3
+)
+
+// autoWildcardResult stores the wildcard detection result for a domain
+type autoWildcardResult struct {
+	isWildcard bool
+	ips        map[string]struct{}
+}
+
+// autoWildcardDetector handles automatic wildcard DNS detection
+type autoWildcardDetector struct {
+	runner *Runner
+	cache  map[string]*autoWildcardResult
+	mu     sync.RWMutex
+}
+
+// newAutoWildcardDetector creates a new auto wildcard detector
+func newAutoWildcardDetector(r *Runner) *autoWildcardDetector {
+	return &autoWildcardDetector{
+		runner: r,
+		cache:  make(map[string]*autoWildcardResult),
+	}
+}
+
+// extractParentDomains returns all possible parent domains for a host.
+// For "a.b.example.com" it returns ["b.example.com", "example.com"]
+func extractParentDomains(host string) []string {
+	parts := strings.Split(host, ".")
+	if len(parts) <= 2 {
+		return nil
+	}
+
+	var parents []string
+	// Start from one level up, stop before the TLD
+	for i := 1; i < len(parts)-1; i++ {
+		parent := strings.Join(parts[i:], ".")
+		parents = append(parents, parent)
+	}
+	return parents
+}
+
+// detect probes a domain for wildcard DNS by querying random subdomains.
+// Returns the cached result if already probed.
+func (d *autoWildcardDetector) detect(domain string) *autoWildcardResult {
+	d.mu.RLock()
+	if result, ok := d.cache[domain]; ok {
+		d.mu.RUnlock()
+		return result
+	}
+	d.mu.RUnlock()
+
+	// Probe with multiple random subdomains
+	allIPs := make(map[string]int) // ip -> count of probes that returned it
+	resolvedProbes := 0
+
+	for i := 0; i < autoWildcardProbes; i++ {
+		randomHost := xid.New().String() + "." + domain
+		in, err := d.runner.dnsx.QueryOne(randomHost)
+		if err != nil || in == nil || len(in.A) == 0 {
+			continue
+		}
+		resolvedProbes++
+		for _, a := range in.A {
+			allIPs[a]++
+		}
+	}
+
+	result := &autoWildcardResult{
+		ips: make(map[string]struct{}),
+	}
+
+	// Domain is wildcard if at least 2 random probes resolved
+	if resolvedProbes >= 2 {
+		result.isWildcard = true
+		// Collect IPs that appeared in at least 2 probes (consistent wildcard IPs)
+		for ip, count := range allIPs {
+			if count >= 2 {
+				result.ips[ip] = struct{}{}
+			}
+		}
+		// If no consistent IPs found but probes resolved, still mark as wildcard
+		// using all observed IPs
+		if len(result.ips) == 0 {
+			for ip := range allIPs {
+				result.ips[ip] = struct{}{}
+			}
+		}
+		gologger.Verbose().Msgf("Auto-wildcard detected for %s (IPs: %d)\n", domain, len(result.ips))
+	}
+
+	d.mu.Lock()
+	d.cache[domain] = result
+	d.mu.Unlock()
+
+	return result
+}
+
+// isWildcardMatch checks if a host's A records match auto-detected wildcard IPs.
+// It checks all parent domain levels for wildcard matches.
+func (d *autoWildcardDetector) isWildcardMatch(host string, aRecords []string) bool {
+	if len(aRecords) == 0 {
+		return false
+	}
+
+	parents := extractParentDomains(host)
+	for _, parent := range parents {
+		result := d.detect(parent)
+		if !result.isWildcard {
+			continue
+		}
+
+		// Check if all A records of the host are wildcard IPs
+		allMatch := true
+		for _, a := range aRecords {
+			if _, ok := result.ips[a]; !ok {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			return true
+		}
+	}
+	return false
+}
+
+// IsWildcard checks if a host is wildcard (used by -wd flag)
 func (r *Runner) IsWildcard(host string) bool {
 	orig := make(map[string]struct{})
 	wildcards := make(map[string]struct{})

--- a/internal/runner/wildcard_test.go
+++ b/internal/runner/wildcard_test.go
@@ -1,0 +1,77 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractParentDomains(t *testing.T) {
+	tests := []struct {
+		host     string
+		expected []string
+	}{
+		{
+			host:     "sub.example.com",
+			expected: []string{"example.com"},
+		},
+		{
+			host:     "deep.sub.example.com",
+			expected: []string{"sub.example.com", "example.com"},
+		},
+		{
+			host:     "a.b.c.example.com",
+			expected: []string{"b.c.example.com", "c.example.com", "example.com"},
+		},
+		{
+			host:     "example.com",
+			expected: nil,
+		},
+		{
+			host:     "com",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			got := extractParentDomains(tt.host)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestAutoWildcardResult_Match(t *testing.T) {
+	result := &autoWildcardResult{
+		isWildcard: true,
+		ips:        map[string]struct{}{"1.2.3.4": {}, "5.6.7.8": {}},
+	}
+
+	// All records match wildcard IPs
+	require.True(t, allRecordsMatchWildcard(result, []string{"1.2.3.4"}))
+	require.True(t, allRecordsMatchWildcard(result, []string{"1.2.3.4", "5.6.7.8"}))
+
+	// Some records don't match
+	require.False(t, allRecordsMatchWildcard(result, []string{"1.2.3.4", "9.9.9.9"}))
+	require.False(t, allRecordsMatchWildcard(result, []string{"9.9.9.9"}))
+
+	// Empty records
+	require.False(t, allRecordsMatchWildcard(result, []string{}))
+
+	// Non-wildcard result
+	nonWildcard := &autoWildcardResult{isWildcard: false, ips: map[string]struct{}{}}
+	require.False(t, allRecordsMatchWildcard(nonWildcard, []string{"1.2.3.4"}))
+}
+
+// allRecordsMatchWildcard is a helper to test the matching logic without DNS queries
+func allRecordsMatchWildcard(result *autoWildcardResult, aRecords []string) bool {
+	if !result.isWildcard || len(aRecords) == 0 {
+		return false
+	}
+	for _, a := range aRecords {
+		if _, ok := result.ips[a]; !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Adds `--auto-wildcard` (`-aw`) flag that automatically detects and filters wildcard DNS records across all domains in a single run, without requiring manual `-wd` specification per domain.

Closes #924

## Changes

- New `--auto-wildcard` / `-aw` flag in the configs group
- `autoWildcardDetector` that lazily probes parent domains for wildcard DNS by querying random subdomains
- Per-domain caching of wildcard detection results for efficiency
- Inline filtering in the resolve worker — hosts whose A records match detected wildcard IPs are skipped
- Multi-level parent domain checking (e.g. for `a.b.example.com`, checks both `b.example.com` and `example.com`)
- Mutual exclusion with `-wd` flag (cannot use both)
- Not supported in stream mode (consistent with existing `-wd` behavior)
- Unit tests for parent domain extraction and wildcard matching logic

## How It Works

1. During resolution, for each host, the detector extracts parent domains
2. For each unique parent domain (cached), it sends 3 random subdomain queries (e.g. `<random>.example.com`)
3. If at least 2 random probes resolve, the domain is marked as wildcard and the consistent IPs are recorded
4. Hosts whose A records are a subset of the wildcard IPs are filtered from output
5. Verbose logging shows which domains are detected as wildcards and which hosts are filtered

## Usage

```bash
# Auto-detect and filter wildcards across all domains
echo -e "real.example.com\nfake.wildcard.io" | dnsx -aw

# With wordlist bruteforce
dnsx -d example.com,wildcard.io -w wordlist.txt -aw

# With verbose output to see wildcard detection
dnsx -l hosts.txt -aw -v
```

## Testing

- All existing tests pass
- New unit tests for `extractParentDomains` and wildcard matching logic
- Build verified with `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a --auto-wildcard (alias -aw) option for automatic wildcard domain filtering.
  - Automatic wildcard detection with caching and parent-domain probing to reduce false positives.
  - Validation prevents using auto-wildcard alongside existing wildcard options or when running in stream mode.

* **Tests**
  - Added unit tests covering parent-domain handling, wildcard detection logic, and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->