### PR TITLE
feat: add --auto-wildcard flag for automatic wildcard detection across multiple domains

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	TraceMaxRecursion     int
 	WildcardThreshold     int
 	WildcardDomain        string
+	AutoWildcard         bool
 	ShowStatistics        bool
 	rcodes                map[int]struct{}
 	RCode                 string
@@ -189,6 +190,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatically detect and filter wildcard DNS across all domains"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "proxy to use (eg socks5://127.0.0.1:8080)"),
 	)
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -59,7 +59,6 @@ type Options struct {
 	TraceMaxRecursion     int
 	WildcardThreshold     int
 	WildcardDomain        string
-	AutoWildcard         bool
 	ShowStatistics        bool
 	rcodes                map[int]struct{}
 	RCode                 string
@@ -80,6 +79,7 @@ type Options struct {
 	DisableUpdateCheck    bool
 	PdcpAuth              string
 	Proxy                 string
+	AutoWildcard          bool
 }
 
 // ShouldLoadResume resume file
@@ -190,7 +190,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.Resolvers, "resolver", "r", "", "list of resolvers to use (file or comma separated)"),
 		flagSet.IntVarP(&options.WildcardThreshold, "wildcard-threshold", "wt", 5, "wildcard filter threshold"),
 		flagSet.StringVarP(&options.WildcardDomain, "wildcard-domain", "wd", "", "domain name for wildcard filtering (other flags will be ignored - only json output is supported)"),
-		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "automatically detect and filter wildcard DNS across all domains"),
+		flagSet.BoolVarP(&options.AutoWildcard, "auto-wildcard", "aw", false, "enable automatic wildcard detection and filtering across multiple domains"),
 		flagSet.StringVar(&options.Proxy, "proxy", "", "proxy to use (eg socks5://127.0.0.1:8080)"),
 	)
 
@@ -308,6 +308,9 @@ func (options *Options) validateOptions() {
 		}
 		if options.WildcardDomain != "" {
 			gologger.Fatal().Msgf("wildcard not supported in stream mode")
+		}
+		if options.AutoWildcard {
+			gologger.Fatal().Msgf("auto-wildcard not supported in stream mode")
 		}
 		if options.ShowStatistics {
 			gologger.Fatal().Msgf("stats not supported in stream mode")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -28,7 +28,14 @@ import (
 	iputil "github.com/projectdiscovery/utils/ip"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 	sliceutil "github.com/projectdiscovery/utils/slice"
+	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
+
+// wildcardTask holds a host and the wildcard domain to use for filtering.
+type wildcardTask struct {
+	host           string
+	wildcardDomain string
+}
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
@@ -39,7 +46,7 @@ type Runner struct {
 	wgwildcardworker    *sync.WaitGroup
 	workerchan          chan string
 	outputchan          chan string
-	wildcardworkerchan  chan string
+	wildcardworkerchan  chan wildcardTask
 	wildcards           *mapsutil.SyncLockMap[string, struct{}]
 	wildcardscache      map[string][]string
 	wildcardscachemutex sync.Mutex
@@ -156,7 +163,7 @@ func New(options *Options) (*Runner, error) {
 		wgresolveworkers:   &sync.WaitGroup{},
 		wgwildcardworker:   &sync.WaitGroup{},
 		workerchan:         make(chan string),
-		wildcardworkerchan: make(chan string),
+		wildcardworkerchan: make(chan wildcardTask),
 		wildcards:          mapsutil.NewSyncLockMap[string, struct{}](),
 		wildcardscache:     make(map[string][]string),
 		limiter:            limiter,
@@ -467,7 +474,7 @@ func (r *Runner) run() error {
 	close(r.outputchan)
 	r.wgoutputworker.Wait()
 
-	if r.options.WildcardDomain != "" {
+	if r.options.WildcardDomain != "" || r.options.AutoWildcard {
 		gologger.Print().Msgf("Starting to filter wildcard subdomains\n")
 		ipDomain := make(map[string]map[string]struct{})
 		listIPs := []string{}
@@ -509,13 +516,23 @@ func (r *Runner) run() error {
 				for host := range hosts {
 					if _, ok := seen[host]; !ok {
 						seen[host] = struct{}{}
-						r.wildcardworkerchan <- host
+						wildcardDomain := r.getWildcardDomainForHost(host)
+						if wildcardDomain == "" {
+							continue
+						}
+						r.wildcardworkerchan <- wildcardTask{host: host, wildcardDomain: wildcardDomain}
 					}
 				}
 			}
 		}
 		close(r.wildcardworkerchan)
 		r.wgwildcardworker.Wait()
+
+		// determine which hosts are root wildcard domains (should be kept)
+		rootDomains := make(map[string]struct{})
+		if r.options.WildcardDomain != "" {
+			rootDomains[r.options.WildcardDomain] = struct{}{}
+		}
 
 		// we need to restart output
 		r.startOutputWorker()
@@ -524,7 +541,7 @@ func (r *Runner) run() error {
 		numRemovedSubdomains := 0
 		for _, A := range listIPs {
 			for host := range ipDomain[A] {
-				if host == r.options.WildcardDomain {
+				if _, isRoot := rootDomains[host]; isRoot {
 					if _, ok := seen[host]; !ok {
 						seen[host] = struct{}{}
 						_ = r.lookupAndOutput(host)
@@ -731,7 +748,7 @@ func (r *Runner) worker() {
 			}
 		}
 		// if wildcard filtering just store the data
-		if r.options.WildcardDomain != "" {
+		if r.options.WildcardDomain != "" || r.options.AutoWildcard {
 			if err := r.storeDNSData(dnsData.DNSData); err != nil {
 				gologger.Debug().Msgf("Failed to store DNS data for %s: %v\n", domain, err)
 			}
@@ -935,13 +952,38 @@ func (r *Runner) wildcardWorker() {
 	defer r.wgwildcardworker.Done()
 
 	for {
-		host, more := <-r.wildcardworkerchan
+		task, more := <-r.wildcardworkerchan
 		if !more {
 			break
 		}
-		if r.IsWildcard(host) {
+		if r.IsWildcard(task.host, task.wildcardDomain) {
 			// mark this host as a wildcard subdomain
-			_ = r.wildcards.Set(host, struct{}{})
+			_ = r.wildcards.Set(task.host, struct{}{})
 		}
 	}
+}
+
+// getWildcardDomainForHost determines the wildcard domain for a given host.
+// If --wildcard-domain is explicitly set, it takes precedence.
+// If --auto-wildcard is enabled, the root domain is derived using EffectiveTLDPlusOne.
+func (r *Runner) getWildcardDomainForHost(host string) string {
+	// explicit wildcard domain always takes precedence
+	if r.options.WildcardDomain != "" {
+		return r.options.WildcardDomain
+	}
+
+	if !r.options.AutoWildcard {
+		return ""
+	}
+
+	// skip IP addresses
+	if host == "" || strings.Contains(host, ":") || iputil.IsIP(host) {
+		return ""
+	}
+
+	domain, err := publicsuffix.Domain(host)
+	if err != nil {
+		return ""
+	}
+	return domain
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -115,7 +115,7 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	// If no option is specified or wildcard filter has been requested use query type A
-	if len(questionTypes) == 0 || options.WildcardDomain != "" {
+	if len(questionTypes) == 0 || options.WildcardDomain != "" || options.AutoWildcard {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)
 	}

--- a/internal/runner/wildcard.go
+++ b/internal/runner/wildcard.go
@@ -6,8 +6,9 @@ import (
 	"github.com/rs/xid"
 )
 
-// IsWildcard checks if a host is wildcard
-func (r *Runner) IsWildcard(host string) bool {
+// IsWildcard checks if a host is wildcard by comparing its A records
+// against random subdomain resolutions under the given wildcardDomain.
+func (r *Runner) IsWildcard(host, wildcardDomain string) bool {
 	orig := make(map[string]struct{})
 	wildcards := make(map[string]struct{})
 
@@ -19,7 +20,7 @@ func (r *Runner) IsWildcard(host string) bool {
 		orig[A] = struct{}{}
 	}
 
-	subdomainPart := strings.TrimSuffix(host, "."+r.options.WildcardDomain)
+	subdomainPart := strings.TrimSuffix(host, "."+wildcardDomain)
 	subdomainTokens := strings.Split(subdomainPart, ".")
 
 	// Build an array by preallocating a slice of a length
@@ -27,11 +28,11 @@ func (r *Runner) IsWildcard(host string) bool {
 	// We use a rand prefix at the beginning like %rand%.domain.tld
 	// A permutation is generated for each level of the subdomain.
 	var hosts []string
-	hosts = append(hosts, r.options.WildcardDomain)
+	hosts = append(hosts, wildcardDomain)
 
 	if len(subdomainTokens) > 0 {
 		for i := 1; i < len(subdomainTokens); i++ {
-			newhost := strings.Join(subdomainTokens[i:], ".") + "." + r.options.WildcardDomain
+			newhost := strings.Join(subdomainTokens[i:], ".") + "." + wildcardDomain
 			hosts = append(hosts, newhost)
 		}
 	}


### PR DESCRIPTION
Implements -aw/--auto-wildcard flag that automatically detects and filters wildcard DNS across multiple domains without requiring per-domain --wildcard-domain specification.

When enabled, the root domain is derived per host using publicsuffix.Domain() (EffectiveTLD+1), and the existing wildcard filtering pipeline is used with per-host wildcard domains.

/claim #924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--auto-wildcard` (shorthand: `-aw`) flag for automatic wildcard domain detection and filtering across multiple targets.
  * Automatic wildcard detection is not available in stream mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->