### PR TITLE
fix: don’t send an extra CNAME query for -a/-aaaa + -cname(/issue#928)

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -114,6 +114,8 @@ func New(options *Options) (*Runner, error) {
 		questionTypes = append(questionTypes, dns.TypeCAA)
 	}
 
+	questionTypes = optimizeQuestionTypes(questionTypes)
+
 	// If no option is specified or wildcard filter has been requested use query type A
 	if len(questionTypes) == 0 || options.WildcardDomain != "" {
 		options.A = true
@@ -824,6 +826,34 @@ func (r *Runner) worker() {
 			r.outputRecordType(domain, dnsData.CAA, "CAA", dnsData.CDNName, dnsData.ASN)
 		}
 	}
+}
+
+func optimizeQuestionTypes(questionTypes []uint16) []uint16 {
+	var hasA, hasAAAA, hasCNAME bool
+	for _, q := range questionTypes {
+		switch q {
+		case dns.TypeA:
+			hasA = true
+		case dns.TypeAAAA:
+			hasAAAA = true
+		case dns.TypeCNAME:
+			hasCNAME = true
+		}
+	}
+
+	// If user only requested {A,CNAME} or {AAAA,CNAME}, keep a single query type.
+	// Resolvers already follow CNAME chains when resolving address records.
+	if hasCNAME && (hasA || hasAAAA) && len(questionTypes) == 2 {
+		optimized := make([]uint16, 0, 1)
+		for _, q := range questionTypes {
+			if q != dns.TypeCNAME {
+				optimized = append(optimized, q)
+			}
+		}
+		return optimized
+	}
+
+	return questionTypes
 }
 
 func (r *Runner) outputRecordType(domain string, items interface{}, queryType, cdnName string, asn *dnsx.AsnResponse) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/projectdiscovery/hmap/store/hybrid"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	"github.com/stretchr/testify/require"
@@ -141,6 +142,23 @@ func TestRunner_fileInput_prepareInput(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not match expected output")
 }
 
+func TestOptimizeQuestionTypes(t *testing.T) {
+	t.Run("keeps single address query when A and CNAME are selected", func(t *testing.T) {
+		got := optimizeQuestionTypes([]uint16{dns.TypeA, dns.TypeCNAME})
+		require.Equal(t, []uint16{dns.TypeA}, got)
+	})
+
+	t.Run("keeps single address query when AAAA and CNAME are selected", func(t *testing.T) {
+		got := optimizeQuestionTypes([]uint16{dns.TypeAAAA, dns.TypeCNAME})
+		require.Equal(t, []uint16{dns.TypeAAAA}, got)
+	})
+
+	t.Run("does not alter query set when more than two record types are selected", func(t *testing.T) {
+		input := []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeCNAME}
+		got := optimizeQuestionTypes(input)
+		require.Equal(t, input, got)
+	})
+}
 func TestRunner_InputWorkerStream(t *testing.T) {
 	options := &Options{
 		Hosts: "tests/stream_input.txt",


### PR DESCRIPTION
/claim #928 
Closes #928 
When -a -cname (or -aaaa -cname) are used together, dnsx currently sends two queries per host.

For this specific combo, the extra CNAME query is unnecessary: resolving A/AAAA already follows CNAME chains, so we can get the same end result with one query type.

This change only optimizes those two exact cases:

A + CNAME → query only A
AAAA + CNAME → query only AAAA
Everything else stays as-is (for example A + AAAA + CNAME is unchanged).

Also added tests to cover:

A + CNAME optimization
AAAA + CNAME optimization
no optimization when more than two types are selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced DNS query efficiency by optimizing type combinations, reducing redundant lookups in specific scenarios to improve overall performance.

* **Tests**
  * Added comprehensive tests to verify optimized query type handling across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->