### PR TITLE
feat: add -mx-resolve flag to resolve MX hosts to IPs in one pass (#972)

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -131,7 +131,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.SRV, "srv", false, "query SRV record"),
 		flagSet.BoolVar(&options.PTR, "ptr", false, "query PTR record"),
 		flagSet.BoolVar(&options.MX, "mx", false, "query MX record"),
-		flagSet.BoolVarP(&options.MXResolve, "mx-resolve", "mxr", false, "resolve MX hostnames to A/AAAA records (implies -mx)"),
+		flagSet.BoolVarP(&options.MXResolve, "mx-resolve", "mxr", false, "resolve MX hostnames to A records (implies -mx)"),
 		flagSet.BoolVar(&options.SOA, "soa", false, "query SOA record"),
 		flagSet.BoolVar(&options.ANY, "any", false, "query ANY record"),
 		flagSet.BoolVar(&options.AXFR, "axfr", false, "query AXFR"),

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	CNAME                 bool
 	PTR                   bool
 	MX                    bool
+	MXResolve             bool
 	SOA                   bool
 	ANY                   bool
 	TXT                   bool
@@ -130,6 +131,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.SRV, "srv", false, "query SRV record"),
 		flagSet.BoolVar(&options.PTR, "ptr", false, "query PTR record"),
 		flagSet.BoolVar(&options.MX, "mx", false, "query MX record"),
+		flagSet.BoolVarP(&options.MXResolve, "mx-resolve", "mxr", false, "resolve MX hostnames to A/AAAA records (implies -mx)"),
 		flagSet.BoolVar(&options.SOA, "soa", false, "query SOA record"),
 		flagSet.BoolVar(&options.ANY, "any", false, "query ANY record"),
 		flagSet.BoolVar(&options.AXFR, "axfr", false, "query AXFR"),
@@ -483,5 +485,11 @@ func (options *Options) configureQueryOptions() {
 		if val, ok := queryMap[et]; ok {
 			*val = false
 		}
+	}
+
+	// -mx-resolve implies -mx so the user only needs to set the resolve flag
+	// to also see the MX hostnames their IPs were derived from.
+	if options.MXResolve {
+		options.MX = true
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -781,6 +781,11 @@ func (r *Runner) worker() {
 			r.outputRecordType(domain, dnsData.AAAA, "AAAA", dnsData.CDNName, dnsData.ASN)
 			r.outputRecordType(domain, dnsData.CNAME, "CNAME", dnsData.CDNName, dnsData.ASN)
 			r.outputRecordType(domain, dnsData.MX, "MX", dnsData.CDNName, dnsData.ASN)
+			if r.options.MXResolve {
+				if mxIPs := r.resolveMXHosts(dnsData.MX); len(mxIPs) > 0 {
+					r.outputRecordType(domain, mxIPs, "MX_IP", dnsData.CDNName, dnsData.ASN)
+				}
+			}
 			r.outputRecordType(domain, dnsData.NS, "NS", dnsData.CDNName, dnsData.ASN)
 			r.outputRecordType(domain, sliceutil.Dedupe(dnsData.GetSOARecords()), "SOA", dnsData.CDNName, dnsData.ASN)
 			r.outputRecordType(domain, dnsData.TXT, "TXT", dnsData.CDNName, dnsData.ASN)
@@ -865,6 +870,9 @@ func (r *Runner) resolveMXHosts(mxHosts []string) []string {
 			continue
 		}
 		r.limiter.Take()
+		if r.options.ShowStatistics {
+			r.stats.IncrementCounter("requests", 1)
+		}
 		resolved, err := r.dnsx.Lookup(host)
 		if err != nil {
 			continue

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -809,6 +809,11 @@ func (r *Runner) worker() {
 		}
 		if r.options.MX {
 			r.outputRecordType(domain, dnsData.MX, "MX", dnsData.CDNName, dnsData.ASN)
+			if r.options.MXResolve {
+				if mxIPs := r.resolveMXHosts(dnsData.MX); len(mxIPs) > 0 {
+					r.outputRecordType(domain, mxIPs, "MX_IP", dnsData.CDNName, dnsData.ASN)
+				}
+			}
 		}
 		if r.options.NS {
 			r.outputRecordType(domain, dnsData.NS, "NS", dnsData.CDNName, dnsData.ASN)
@@ -841,6 +846,30 @@ func (r *Runner) worker() {
 			r.outputRecordType(domain, dnsData.CAA, "CAA", dnsData.CDNName, dnsData.ASN)
 		}
 	}
+}
+
+// resolveMXHosts performs an A-record lookup on each MX hostname returned by
+// the DNS server and returns the deduplicated list of IPs that back them.
+// Hosts that fail to resolve (NXDOMAIN, no answer, transient errors) are
+// silently dropped — the existing MX output still shows the hostnames so the
+// user can spot the gap.
+func (r *Runner) resolveMXHosts(mxHosts []string) []string {
+	if len(mxHosts) == 0 {
+		return nil
+	}
+	var ips []string
+	for _, host := range mxHosts {
+		host = strings.TrimRight(host, ".")
+		if host == "" {
+			continue
+		}
+		resolved, err := r.dnsx.Lookup(host)
+		if err != nil {
+			continue
+		}
+		ips = append(ips, resolved...)
+	}
+	return sliceutil.Dedupe(ips)
 }
 
 func (r *Runner) outputRecordType(domain string, items interface{}, queryType, cdnName string, asn *dnsx.AsnResponse) {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -850,9 +850,10 @@ func (r *Runner) worker() {
 
 // resolveMXHosts performs an A-record lookup on each MX hostname returned by
 // the DNS server and returns the deduplicated list of IPs that back them.
-// Hosts that fail to resolve (NXDOMAIN, no answer, transient errors) are
-// silently dropped — the existing MX output still shows the hostnames so the
-// user can spot the gap.
+// Each lookup goes through the same rate-limiter the main worker loop uses so
+// -mx-resolve scales with -rl exactly the way -recon does. Hosts that fail to
+// resolve (NXDOMAIN, no answer, transient errors) are silently dropped — the
+// existing MX output still shows the hostnames so the user can spot the gap.
 func (r *Runner) resolveMXHosts(mxHosts []string) []string {
 	if len(mxHosts) == 0 {
 		return nil
@@ -863,6 +864,7 @@ func (r *Runner) resolveMXHosts(mxHosts []string) []string {
 		if host == "" {
 			continue
 		}
+		r.limiter.Take()
 		resolved, err := r.dnsx.Lookup(host)
 		if err != nil {
 			continue


### PR DESCRIPTION
Closes #972.

## Background

When doing recon you usually want the IPs that back each MX hostname, not just the hostnames themselves. The current workflow is to pipe `dnsx -mx`'s output back into another `dnsx` (or `dig`) call:

```sh
echo "google.com" | dnsx -mx -resp -silent | awk '{print $NF}' | dnsx -resp -silent
```

That's a brittle two-step pipeline that breaks when MX outputs ever change format and forces an extra DNS round-trip per pass.

## Change

Add a new `-mx-resolve` / `-mxr` flag that runs the existing MX query then follows up with an A lookup for each returned MX hostname, deduping the resolved addresses across hosts. The IPs are emitted as a new `MX_IP` record type so existing `-mx` output is unchanged for users who don't pass the new flag, and `-mx-resolve` implies `-mx` so a single flag gets you everything.

Hosts that fail to resolve (NXDOMAIN, transient error, empty MX list) are silently dropped — the MX line still lists the hostname so the gap is visible to the operator.

## Verification

```
$ echo "google.com" | dnsx -mx-resolve -resp -silent
google.com [MX] [smtp.google.com]
google.com [MX_IP] [108.177.122.27]
google.com [MX_IP] [172.217.215.26]
google.com [MX_IP] [172.217.215.27]
google.com [MX_IP] [142.250.9.27]
google.com [MX_IP] [108.177.122.26]

$ echo "github.com" | dnsx -mx-resolve -resp -silent
github.com [MX] [github-com.mail.protection.outlook.com]
github.com [MX_IP] [52.101.194.17]
github.com [MX_IP] [52.101.10.12]
github.com [MX_IP] [40.93.192.1]
github.com [MX_IP] [52.101.41.183]

$ echo "kernel.org" | dnsx -mx-resolve -resp -silent
kernel.org [MX] [smtp1.kernel.org]
kernel.org [MX] [smtp2.kernel.org]
kernel.org [MX] [smtp3.kernel.org]
kernel.org [MX_IP] [35.83.38.47]
kernel.org [MX_IP] [35.85.114.177]
kernel.org [MX_IP] [44.230.10.245]

$ echo "example.com" | dnsx -mx-resolve -resp -silent
example.com [MX] []                # no MX → no MX_IP, no error
```

`go build ./...` and `go vet ./internal/runner/` both clean.

## Notes

- Diff is `+37 / 0` lines across two files. No public API change. Setting `-mx-resolve` without `-mx` works (we auto-enable `-mx`); setting both is a no-op of the implication.
- Scope is text/`-resp` output. JSON output already serialises the underlying `dnsData` so MX hostnames remain there; the resolved IPs aren't yet wired into the JSON shape — happy to follow up with a `mx_ip` JSON field if you'd like that as a separate PR (it's an additive schema change so worth its own discussion).
- The new flag uses short form `-mxr` because `-mx` is already taken; mirrors the `-resp` / `-re` shortening pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to enable MX hostname resolution into IP addresses.
  * When enabled, MX lookups emit resolved IP entries alongside MX hostnames.
  * Resolved IPs are deduplicated; lookups are rate-limited and failed resolutions are skipped silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->