### PR TITLE
fix: filter JSON/raw output by record type (#986)

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -66,6 +66,7 @@ type Options struct {
 	RCode                 string
 	ResponseTypeFilter    string
 	responseTypeFilterMap []string
+	explicitRecordTypes   bool
 	hasRCodes             bool
 	Resume                bool
 	resumeCfg             *ResumeCfg

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -139,6 +139,8 @@ func New(options *Options) (*Runner, error) {
 		questionTypes = append(questionTypes, dns.TypeCAA)
 	}
 
+	options.explicitRecordTypes = len(questionTypes) > 0
+
 	// If no option is specified or manual wildcard filtering has been requested, use query type A.
 	// Auto wildcard mode uses internal address probes and preserves the selected record types.
 	if len(questionTypes) == 0 || options.WildcardDomain != "" {
@@ -775,6 +777,14 @@ func (r *Runner) worker() {
 			continue
 		}
 
+		// JSON and raw output emit a whole host record at once, so they must
+		// apply the record-type selectors themselves to stay consistent with
+		// the text output, which only prints hosts that have a matching record.
+		// AXFR keeps its own full-dump contract and is left untouched.
+		if (r.options.JSON || r.options.Raw) && r.options.explicitRecordTypes && !r.options.QueryAll && !r.options.AXFR && !r.hasSelectedRecord(&dnsData) {
+			continue
+		}
+
 		if r.options.JSON {
 			var marshalOptions []dnsx.MarshalOption
 			if r.options.OmitRaw {
@@ -896,6 +906,24 @@ func (r *Runner) outputResponseCode(domain string, responsecode int) {
 	if ok {
 		r.outputchan <- domain + " [" + responseCodeExt + "]"
 	}
+}
+
+func (r *Runner) hasSelectedRecord(dnsData *dnsx.ResponseData) bool {
+	switch {
+	case r.options.A && len(dnsData.A) > 0,
+		r.options.AAAA && len(dnsData.AAAA) > 0,
+		r.options.CNAME && len(dnsData.CNAME) > 0,
+		r.options.NS && len(dnsData.NS) > 0,
+		r.options.TXT && len(dnsData.TXT) > 0,
+		r.options.SRV && len(dnsData.SRV) > 0,
+		r.options.PTR && len(dnsData.PTR) > 0,
+		r.options.MX && len(dnsData.MX) > 0,
+		r.options.SOA && len(dnsData.SOA) > 0,
+		r.options.CAA && len(dnsData.CAA) > 0,
+		r.options.ANY:
+		return true
+	}
+	return false
 }
 
 func (r *Runner) shouldSkipRecord(dnsData *dnsx.ResponseData) bool {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/projectdiscovery/hmap/store/hybrid"
+	"github.com/projectdiscovery/retryabledns"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	"github.com/stretchr/testify/require"
 )
@@ -268,4 +270,30 @@ func TestNewRejectsInvalidWildcardDomain(t *testing.T) {
 	runner, err := New(&Options{WildcardDomain: "foo bar"})
 	require.Nil(t, runner)
 	require.EqualError(t, err, "invalid wildcard domain")
+}
+
+func TestHasSelectedRecord(t *testing.T) {
+	withCNAME := &dnsx.ResponseData{DNSData: &retryabledns.DNSData{CNAME: []string{"target.example.com"}}}
+	withA := &dnsx.ResponseData{DNSData: &retryabledns.DNSData{A: []string{"1.2.3.4"}}}
+	empty := &dnsx.ResponseData{DNSData: &retryabledns.DNSData{}}
+
+	tests := []struct {
+		name     string
+		options  *Options
+		data     *dnsx.ResponseData
+		expected bool
+	}{
+		{"cname requested and present", &Options{CNAME: true}, withCNAME, true},
+		{"cname requested but absent", &Options{CNAME: true}, withA, false},
+		{"a requested and present", &Options{A: true}, withA, true},
+		{"any of several requested types present", &Options{A: true, CNAME: true}, withA, true},
+		{"any record type always matches", &Options{ANY: true}, empty, true},
+		{"no requested type present", &Options{CNAME: true, MX: true}, empty, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Runner{options: tt.options}
+			require.Equal(t, tt.expected, r.hasSelectedRecord(tt.data))
+		})
+	}
 }


### PR DESCRIPTION
Closes #986.

JSON/raw output emitted every resolved host regardless of the requested record type, unlike text output. Now filtered to hosts with a matching record. Default, `-all` and AXFR are untouched.

Note: `-cname` etc. now also filter JSON/raw output, not just query. Tightly scoped to explicit selectors so existing `-j` full-dump pipelines are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When explicitly selecting specific DNS record types, JSON and raw output formats now filter results to display only matching records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->