### PR TITLE
feat: add -output-template flag for custom output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ UPDATE:
    -duc, -disable-update-check  disable automatic dnsx update check
 
 OUTPUT:
-   -o, -output string  file to write output
-   -j, -json           write output in JSONL(ines) format
-   -omit-raw, -or      omit raw dns response from jsonl output
+   -o, -output string           file to write output
+   -j, -json                    write output in JSONL(ines) format
+   -omit-raw, -or               omit raw dns response from jsonl output
+   -ot, -output-template string custom output template (e.g. -ot '{{host}} {{a}}')
 
 DEBUG:
    -hc, -health-check  run diagnostic check up
@@ -291,6 +292,33 @@ paypal-portal.com
 micropayments.paypal-labs.com
 minicart.paypal-labs.com
 ```
+---------
+
+### Custom Output Format
+
+The `-output-template` (`-ot`) flag lets you customize the output format using a template, instead of the default bracketed layout (e.g. `example.com [A] [104.20.23.154]`). You specify the template directly on the command line to control how the resolved data is presented.
+
+Template variables map to the same field names used in the JSONL output (`-json`), so any of the following can be referenced as `{{field}}`:
+
+`host`, `a`, `aaaa`, `cname`, `ns`, `txt`, `mx`, `srv`, `ptr`, `soa`, `caa`, `ttl`, `resolver`, `status_code`, `cdn-name`, `cdn-type`, `asn`, `query-time`. A convenience `{{ip}}` alias holds the combined `A` and `AAAA` records.
+
+Records with multiple values (e.g. several `A` records) are comma-joined within a single field.
+
+```console
+echo example.com | dnsx -silent -a -ot '{{host}} {{a}}'
+
+example.com 104.20.23.154,172.66.147.243
+```
+
+```console
+echo example.com | dnsx -silent -a -ot '{{ip}} - {{host}}'
+
+104.20.23.154,172.66.147.243 - example.com
+```
+
+> [!NOTE]
+> If a specified field does not exist or does not contain a value, it is simply omitted from the output. `-output-template` cannot be combined with `-json` or `-raw`.
+
 ---------
 
 ### DNS Bruteforce

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/projectdiscovery/retryabledns v1.0.115
 	github.com/projectdiscovery/utils v0.11.1
 	github.com/stretchr/testify v1.11.1
+	github.com/valyala/fasttemplate v1.2.2
 )
 
 require (
@@ -92,6 +93,7 @@ require (
 	github.com/tidwall/tinyqueue v0.1.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/weppos/publicsuffix-go v0.50.3-0.20260104170930-90713dec78f2 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,10 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
+github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/weppos/publicsuffix-go v0.13.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.40.2/go.mod h1:XsLZnULC3EJ1Gvk9GVjuCTZ8QUu9ufE4TZpOizDShko=
 github.com/weppos/publicsuffix-go v0.50.3-0.20260104170930-90713dec78f2 h1:LiQSn5u8Nc6V/GixI+SWxt+YkNIyfKIlkVRULSw2Zt0=

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	RateLimit             int
 	Retries               int
 	OutputFormat          string
+	OutputTemplate        string
 	OutputFile            string
 	Raw                   bool
 	Silent                bool
@@ -165,6 +166,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputFile, "output", "o", "", "file to write output"),
 		flagSet.BoolVarP(&options.JSON, "json", "j", false, "write output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.OmitRaw, "or", "omit-raw", false, "omit raw dns response from jsonl output"),
+		flagSet.StringVarP(&options.OutputTemplate, "output-template", "ot", "", "custom output template (e.g. -ot '{{host}} {{a}}')"),
 	)
 
 	flagSet.CreateGroup("debug", "Debug",
@@ -275,6 +277,10 @@ func ParseOptions() *Options {
 func (options *Options) validateOptions() {
 	if options.Response && options.ResponseOnly {
 		gologger.Fatal().Msgf("resp and resp-only can't be used at the same time")
+	}
+
+	if options.OutputTemplate != "" && (options.JSON || options.Raw) {
+		gologger.Fatal().Msgf("output-template can't be used with json or raw output")
 	}
 
 	if options.Retries == 0 {

--- a/internal/runner/output_template.go
+++ b/internal/runner/output_template.go
@@ -1,0 +1,92 @@
+package runner
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/gologger"
+)
+
+// buildTemplateFields flattens a ResponseData into a map of template variables
+// keyed by their JSON field names (e.g. host, a, aaaa, cname, ns, ...). Slice
+// values are comma-joined and scalar values are stringified so they can be
+// substituted directly into an output template. A convenience "ip" alias holds
+// the combined A and AAAA records.
+func buildTemplateFields(dnsData *dnsx.ResponseData) (map[string]string, error) {
+	jsonStr, err := dnsData.JSON()
+	if err != nil {
+		return nil, err
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		return nil, err
+	}
+
+	fields := make(map[string]string, len(raw)+1)
+	for k, v := range raw {
+		fields[k] = stringifyTemplateValue(v)
+	}
+
+	// convenience alias: {{ip}} = A and AAAA records combined
+	ips := make([]string, 0, 2)
+	if a := fields["a"]; a != "" {
+		ips = append(ips, a)
+	}
+	if aaaa := fields["aaaa"]; aaaa != "" {
+		ips = append(ips, aaaa)
+	}
+	fields["ip"] = strings.Join(ips, ",")
+
+	return fields, nil
+}
+
+// stringifyTemplateValue converts a decoded JSON value into its template
+// string representation, joining slices with commas.
+func stringifyTemplateValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []any:
+		parts := make([]string, 0, len(val))
+		for _, item := range val {
+			parts = append(parts, stringifyTemplateValue(item))
+		}
+		return strings.Join(parts, ",")
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(val)
+	case nil:
+		return ""
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}
+
+// outputTemplateRecord renders a single host record using the user-supplied
+// output template and pushes the result to the output channel. Unknown or empty
+// tags are rendered as empty strings.
+func (r *Runner) outputTemplateRecord(dnsData *dnsx.ResponseData) {
+	fields, err := buildTemplateFields(dnsData)
+	if err != nil {
+		gologger.Warning().Msgf("could not build template fields for %s: %s", dnsData.Host, err)
+		return
+	}
+
+	out, err := r.outputTemplate.ExecuteFuncStringWithErr(func(w io.Writer, tag string) (int, error) {
+		return w.Write([]byte(fields[tag]))
+	})
+	if err != nil {
+		gologger.Warning().Msgf("could not render output template: %s", err)
+		return
+	}
+
+	r.outputchan <- out
+}

--- a/internal/runner/output_template.go
+++ b/internal/runner/output_template.go
@@ -25,7 +25,7 @@ func buildTemplateFields(dnsData *dnsx.ResponseData) (map[string]string, error) 
 		return nil, err
 	}
 
-	fields := make(map[string]string, len(raw)+1)
+	fields := make(map[string]string, len(raw))
 	for k, v := range raw {
 		fields[k] = stringifyTemplateValue(v)
 	}

--- a/internal/runner/output_template_test.go
+++ b/internal/runner/output_template_test.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"io"
+	"testing"
+
+	"github.com/projectdiscovery/dnsx/libs/dnsx"
+	"github.com/projectdiscovery/retryabledns"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasttemplate"
+)
+
+func TestBuildTemplateFields(t *testing.T) {
+	dnsData := &dnsx.ResponseData{
+		DNSData: &retryabledns.DNSData{
+			Host:  "example.com",
+			A:     []string{"104.20.23.154", "172.66.147.243"},
+			AAAA:  []string{"2606:4700:10::6814:179a"},
+			CNAME: []string{"alias.example.com"},
+		},
+		CDNName: "cloudflare",
+	}
+
+	fields, err := buildTemplateFields(dnsData)
+	require.NoError(t, err)
+
+	require.Equal(t, "example.com", fields["host"])
+	require.Equal(t, "104.20.23.154,172.66.147.243", fields["a"])
+	require.Equal(t, "2606:4700:10::6814:179a", fields["aaaa"])
+	require.Equal(t, "alias.example.com", fields["cname"])
+	require.Equal(t, "cloudflare", fields["cdn-name"])
+	// ip alias combines A and AAAA records
+	require.Equal(t, "104.20.23.154,172.66.147.243,2606:4700:10::6814:179a", fields["ip"])
+	// unset fields are absent
+	require.Empty(t, fields["mx"])
+}
+
+func TestOutputTemplateRendering(t *testing.T) {
+	dnsData := &dnsx.ResponseData{
+		DNSData: &retryabledns.DNSData{
+			Host: "example.com",
+			A:    []string{"104.20.23.154"},
+		},
+	}
+	fields, err := buildTemplateFields(dnsData)
+	require.NoError(t, err)
+
+	tests := []struct {
+		template string
+		expected string
+	}{
+		{"{{host}} {{a}}", "example.com 104.20.23.154"},
+		{"{{ip}} - {{host}}", "104.20.23.154 - example.com"},
+		{"{{host}}|{{unknown}}|end", "example.com||end"}, // unknown tag -> empty
+	}
+
+	for _, tt := range tests {
+		tmpl, err := fasttemplate.NewTemplate(tt.template, "{{", "}}")
+		require.NoError(t, err)
+		out := tmpl.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {
+			return w.Write([]byte(fields[tag]))
+		})
+		require.Equal(t, tt.expected, out)
+	}
+}

--- a/internal/runner/output_template_test.go
+++ b/internal/runner/output_template_test.go
@@ -35,6 +35,17 @@ func TestBuildTemplateFields(t *testing.T) {
 	require.Empty(t, fields["mx"])
 }
 
+func TestStringifyTemplateValue(t *testing.T) {
+	require.Equal(t, "example.com", stringifyTemplateValue("example.com"))
+	require.Equal(t, "1.1.1.1,2.2.2.2", stringifyTemplateValue([]any{"1.1.1.1", "2.2.2.2"}))
+	require.Equal(t, "300", stringifyTemplateValue(float64(300)))
+	require.Equal(t, "3.14", stringifyTemplateValue(3.14))
+	require.Equal(t, "true", stringifyTemplateValue(true))
+	require.Equal(t, "", stringifyTemplateValue(nil))
+	// nested/object values fall back to their JSON representation
+	require.Equal(t, `{"as-number":"AS123"}`, stringifyTemplateValue(map[string]any{"as-number": "AS123"}))
+}
+
 func TestOutputTemplateRendering(t *testing.T) {
 	dnsData := &dnsx.ResponseData{
 		DNSData: &retryabledns.DNSData{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -31,6 +31,7 @@ import (
 	iputil "github.com/projectdiscovery/utils/ip"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 	sliceutil "github.com/projectdiscovery/utils/slice"
+	"github.com/valyala/fasttemplate"
 )
 
 // Runner is a client for running the enumeration process.
@@ -56,6 +57,7 @@ type Runner struct {
 	tmpStdinFile         string
 	droppedDomains       atomic.Int64
 	aurora               *aurora.Aurora
+	outputTemplate       *fasttemplate.Template
 }
 
 type wildcardJob struct {
@@ -214,6 +216,14 @@ func New(options *Options) (*Runner, error) {
 		hm:                   hm,
 		stats:                stats,
 		aurora:               aurora.New(aurora.WithColors(!options.NoColor)),
+	}
+
+	if options.OutputTemplate != "" {
+		tmpl, err := fasttemplate.NewTemplate(options.OutputTemplate, "{{", "}}")
+		if err != nil {
+			return nil, errors.Wrap(err, "could not parse output template")
+		}
+		r.outputTemplate = tmpl
 	}
 
 	return &r, nil
@@ -781,7 +791,12 @@ func (r *Runner) worker() {
 		// apply the record-type selectors themselves to stay consistent with
 		// the text output, which only prints hosts that have a matching record.
 		// AXFR keeps its own full-dump contract and is left untouched.
-		if (r.options.JSON || r.options.Raw) && r.options.explicitRecordTypes && !r.options.QueryAll && !r.options.AXFR && !r.hasSelectedRecord(&dnsData) {
+		if (r.options.JSON || r.options.Raw || r.options.OutputTemplate != "") && r.options.explicitRecordTypes && !r.options.QueryAll && !r.options.AXFR && !r.hasSelectedRecord(&dnsData) {
+			continue
+		}
+
+		if r.options.OutputTemplate != "" {
+			r.outputTemplateRecord(&dnsData)
 			continue
 		}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -787,10 +787,10 @@ func (r *Runner) worker() {
 			continue
 		}
 
-		// JSON and raw output emit a whole host record at once, so they must
-		// apply the record-type selectors themselves to stay consistent with
-		// the text output, which only prints hosts that have a matching record.
-		// AXFR keeps its own full-dump contract and is left untouched.
+		// JSON, raw, and template output emit a whole host record at once, so
+		// they must apply the record-type selectors themselves to stay
+		// consistent with the text output, which only prints hosts that have a
+		// matching record. AXFR keeps its own full-dump contract and is left untouched.
 		if (r.options.JSON || r.options.Raw || r.options.OutputTemplate != "") && r.options.explicitRecordTypes && !r.options.QueryAll && !r.options.AXFR && !r.hasSelectedRecord(&dnsData) {
 			continue
 		}


### PR DESCRIPTION
Closes #992

### Summary
Adds an `-output-template` / `-ot` flag that lets users define a custom output format instead of the fixed bracketed layout (`example.com [A] [104.20.23.154]`), mirroring katana's `-output-template`.

```console
$ echo example.com | dnsx -silent -a -ot '{{host}} {{a}}'
example.com 104.20.23.154,172.66.147.243

$ echo example.com | dnsx -silent -a -ot '{{ip}} - {{host}}'
104.20.23.154,172.66.147.243 - example.com
```

This resolves the request to reorder/select fields, drop the brackets, and clean up output without post-processing (`tr -d "[]"`).

### Details
- Template variables map to the JSONL field names (`host`, `a`, `aaaa`, `cname`, `ns`, `txt`, `mx`, `cdn-name`, `asn`, `query-time`, ...), plus a convenience `{{ip}}` alias for combined A/AAAA records.
- Multi-value records are comma-joined; renders once per host.
- Missing/unknown tags render as empty strings.
- Mutually exclusive with `-json` / `-raw` (validated).
- Uses `valyala/fasttemplate` (same lib katana uses).

### Testing
- New unit tests in `internal/runner/output_template_test.go`.
- `go build ./...`, `golangci-lint run ./...` (0 issues), and `go test ./internal/runner/` all pass.
- Verified live against real DNS (single/multi host, A+AAAA, cdn/asn fields, unknown-tag, record-type guard, validation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-ot/--output-template` to customize DNS output with `{{field}}` placeholders, including combined `ip` (A+AAAA) formatting.
  * Rendering supports multi-value joining and omits missing fields; unknown tags output as empty values.

* **Bug Fixes**
  * Enforced that `--output-template` can’t be used with `--json` or `--raw/--debug` output modes.

* **Documentation**
  * Updated `dnsx -h` usage text and added a “Custom Output Format” section with examples and template variable list.

* **Tests**
  * Added unit tests for field computation, value stringification, and template rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->