### PR TITLE
bump version to 1.3.0

### DIFF
--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -18,7 +18,7 @@ const banner = `
 const ToolName = `dnsx`
 
 // version is the current version of dnsx
-const version = `1.2.3`
+const version = `1.3.0`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
v1.3.0 was tagged without updating the hardcoded version in banner.go, so -version and the updater still reported 1.2.3 after a successful update. dnsx has no version-bump workflow (same as httpx/nuclei), so this sets the const to 1.3.0.

Already published v1.3.0 binaries stay wrong until a new release is cut. Closes #1002.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.3.0.
  * Update checks and downloads now use the latest version identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->