### PR TITLE
Update Go base image to version 1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache build-base
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM golang:1.25-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 RUN apk add --no-cache build-base
 WORKDIR /app


### PR DESCRIPTION
1.24 gives the following error:

 => ERROR [builder 5/6] RUN go mod download                                                                                                                                            0.6s
------                                                                                                                                                                                      
 > [builder 5/6] RUN go mod download:
0.428 go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local) ------
Dockerfile:7
--------------------
   5 |     WORKDIR /app
   6 |     COPY . /app
   7 | >>> RUN go mod download
   8 |     RUN go build ./cmd/dnsx
   9 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Go 1.27, improving compatibility with the latest Go toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->