### PR TITLE
fix: bump version constant to 1.3.1

### DIFF
--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -18,7 +18,7 @@ const banner = `
 const ToolName = `dnsx`
 
 // version is the current version of dnsx
-const version = `1.2.3`
+const version = `1.3.1`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
Closes #1011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->