### PR TITLE
feat(runner): add -query-type and -exclude-type flags (#403)

### DIFF
--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -486,6 +486,14 @@ func (options *Options) queryMap() map[string]*bool {
 func (options *Options) configureQueryOptions() error {
 	queryMap := options.queryMap()
 
+	hasExplicitSelection := len(options.QueryType) > 0 || options.QueryAll
+	for _, enabled := range queryMap {
+		if *enabled {
+			hasExplicitSelection = true
+			break
+		}
+	}
+
 	for _, qt := range options.QueryType {
 		qt = strings.TrimSpace(strings.ToLower(qt))
 		if qt == "all" {
@@ -517,6 +525,19 @@ func (options *Options) configureQueryOptions() error {
 			*val = false
 		} else {
 			return fmt.Errorf("unsupported exclude type: %s", et)
+		}
+	}
+
+	if hasExplicitSelection {
+		hasActive := false
+		for _, enabled := range queryMap {
+			if *enabled {
+				hasActive = true
+				break
+			}
+		}
+		if !hasActive {
+			return errors.New("no query types remain after exclusions")
 		}
 	}
 

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -17,12 +17,28 @@ import (
 	"github.com/projectdiscovery/utils/auth/pdcp"
 	"github.com/projectdiscovery/utils/env"
 	fileutil "github.com/projectdiscovery/utils/file"
+	sliceutil "github.com/projectdiscovery/utils/slice"
 	updateutils "github.com/projectdiscovery/utils/update"
 )
 
 const (
 	DefaultResumeFile = "resume.cfg"
 )
+
+var SupportedQueryTypes = []string{
+	"a",
+	"aaaa",
+	"cname",
+	"ns",
+	"txt",
+	"srv",
+	"ptr",
+	"mx",
+	"soa",
+	"axfr",
+	"caa",
+	"any",
+}
 
 var PDCPApiKey string
 
@@ -76,7 +92,8 @@ type Options struct {
 	Timeout               time.Duration
 	CAA                   bool
 	QueryAll              bool
-	ExcludeType           []string
+	QueryType             goflags.StringSlice
+	ExcludeType           goflags.StringSlice
 	OutputCDN             bool
 	ASN                   bool
 	HealthCheck           bool
@@ -107,22 +124,6 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.WordList, "wordlist", "w", "", "list of words to bruteforce (file or comma separated or stdin)"),
 	)
 
-	queries := goflags.AllowdTypes{
-		"none":  goflags.EnumVariable(0),
-		"a":     goflags.EnumVariable(1),
-		"aaaa":  goflags.EnumVariable(2),
-		"cname": goflags.EnumVariable(3),
-		"ns":    goflags.EnumVariable(4),
-		"txt":   goflags.EnumVariable(5),
-		"srv":   goflags.EnumVariable(6),
-		"ptr":   goflags.EnumVariable(7),
-		"mx":    goflags.EnumVariable(8),
-		"soa":   goflags.EnumVariable(9),
-		"axfr":  goflags.EnumVariable(10),
-		"caa":   goflags.EnumVariable(11),
-		"any":   goflags.EnumVariable(12),
-	}
-
 	flagSet.CreateGroup("query", "Query",
 		flagSet.BoolVar(&options.A, "a", false, "query A record (default)"),
 		flagSet.BoolVar(&options.AAAA, "aaaa", false, "query AAAA record"),
@@ -137,7 +138,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.AXFR, "axfr", false, "query AXFR"),
 		flagSet.BoolVar(&options.CAA, "caa", false, "query CAA record"),
 		flagSet.BoolVarP(&options.QueryAll, "recon", "all", false, "query all the dns records (a,aaaa,cname,ns,txt,srv,ptr,mx,soa,axfr,caa)"),
-		flagSet.EnumSliceVarP(&options.ExcludeType, "exclude-type", "e", []goflags.EnumVariable{0}, "dns query type to exclude (a,aaaa,cname,ns,txt,srv,ptr,mx,soa,axfr,caa)", queries),
+		flagSet.StringSliceVarP(&options.QueryType, "query-type", "q", nil, "dns query type to resolve (a,aaaa,cname,ns,txt,srv,ptr,mx,soa,axfr,caa,any,all)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.ExcludeType, "exclude-type", "eq", nil, "dns query type to exclude (a,aaaa,cname,ns,txt,srv,ptr,mx,soa,axfr,caa)", goflags.NormalizedStringSliceOptions),
 	)
 
 	flagSet.CreateGroup("filter", "Filter",
@@ -476,6 +478,17 @@ func (options *Options) configureQueryOptions() {
 		"any":   &options.ANY,
 	}
 
+	for _, qt := range options.QueryType {
+		qt = strings.TrimSpace(strings.ToLower(qt))
+		if qt == "all" {
+			for _, val := range queryMap {
+				*val = true
+			}
+		} else if val, ok := queryMap[qt]; ok {
+			*val = true
+		}
+	}
+
 	if options.QueryAll {
 		for _, val := range queryMap {
 			*val = true
@@ -483,10 +496,13 @@ func (options *Options) configureQueryOptions() {
 		options.Response = true
 		// the ANY query type is not supported by the retryabledns library,
 		// thus it's hard to filter the results when it's used in combination with other query types
-		options.ExcludeType = append(options.ExcludeType, "any")
+		if !sliceutil.Contains(options.ExcludeType, "any") {
+			options.ExcludeType = append(options.ExcludeType, "any")
+		}
 	}
 
 	for _, et := range options.ExcludeType {
+		et = strings.TrimSpace(strings.ToLower(et))
 		if val, ok := queryMap[et]; ok {
 			*val = false
 		}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -226,7 +227,10 @@ func ParseOptions() *Options {
 		options.responseTypeFilterMap = validTypes
 	}
 
-	options.configureQueryOptions()
+	err = options.configureQueryOptions()
+	if err != nil {
+		gologger.Fatal().Msgf("%s\n", err)
+	}
 
 	err = options.configureRcodes()
 	if err != nil {
@@ -462,8 +466,8 @@ func (options *Options) configureResume() error {
 	return nil
 }
 
-func (options *Options) configureQueryOptions() {
-	queryMap := map[string]*bool{
+func (options *Options) queryMap() map[string]*bool {
+	return map[string]*bool{
 		"a":     &options.A,
 		"aaaa":  &options.AAAA,
 		"cname": &options.CNAME,
@@ -477,6 +481,10 @@ func (options *Options) configureQueryOptions() {
 		"caa":   &options.CAA,
 		"any":   &options.ANY,
 	}
+}
+
+func (options *Options) configureQueryOptions() error {
+	queryMap := options.queryMap()
 
 	for _, qt := range options.QueryType {
 		qt = strings.TrimSpace(strings.ToLower(qt))
@@ -486,6 +494,8 @@ func (options *Options) configureQueryOptions() {
 			}
 		} else if val, ok := queryMap[qt]; ok {
 			*val = true
+		} else {
+			return fmt.Errorf("unsupported query type: %s", qt)
 		}
 	}
 
@@ -505,6 +515,10 @@ func (options *Options) configureQueryOptions() {
 		et = strings.TrimSpace(strings.ToLower(et))
 		if val, ok := queryMap[et]; ok {
 			*val = false
+		} else {
+			return fmt.Errorf("unsupported exclude type: %s", et)
 		}
 	}
+
+	return nil
 }

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -13,7 +13,8 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 			QueryType:   goflags.StringSlice{"all"},
 			ExcludeType: goflags.StringSlice{"ptr", "axfr", "any"},
 		}
-		options.configureQueryOptions()
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
 
 		require.True(t, options.A)
 		require.True(t, options.AAAA)
@@ -34,7 +35,8 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 		options := &Options{
 			QueryType: goflags.StringSlice{"a", "cname", "txt"},
 		}
-		options.configureQueryOptions()
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
 
 		require.True(t, options.A)
 		require.True(t, options.CNAME)
@@ -55,7 +57,8 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 		options := &Options{
 			QueryType: goflags.StringSlice{"A", "AAAA"},
 		}
-		options.configureQueryOptions()
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
 
 		require.True(t, options.A)
 		require.True(t, options.AAAA)
@@ -77,7 +80,8 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 			AAAA: true,
 			MX:   true,
 		}
-		options.configureQueryOptions()
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
 
 		require.True(t, options.AAAA)
 		require.True(t, options.MX)
@@ -98,7 +102,8 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 		options := &Options{
 			QueryAll: true,
 		}
-		options.configureQueryOptions()
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
 
 		require.True(t, options.A)
 		require.True(t, options.AAAA)
@@ -114,6 +119,24 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 		require.False(t, options.ANY)
 		require.True(t, options.Response)
 	})
+
+	t.Run("invalid query type returns error", func(t *testing.T) {
+		options := &Options{
+			QueryType: goflags.StringSlice{"invalid_type"},
+		}
+		err := options.configureQueryOptions()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported query type: invalid_type")
+	})
+
+	t.Run("invalid exclude type returns error", func(t *testing.T) {
+		options := &Options{
+			ExcludeType: goflags.StringSlice{"invalid_type"},
+		}
+		err := options.configureQueryOptions()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported exclude type: invalid_type")
+	})
 }
 
 func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
@@ -122,6 +145,7 @@ func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
 		args        []string
 		expected    map[string]bool
 		notExpected map[string]bool
+		expectErr   bool
 	}{
 		{
 			name: "short flags -q and -eq",
@@ -136,12 +160,12 @@ func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
 		},
 		{
 			name: "long flags -query-type and -exclude-type",
-			args: []string{"-query-type", "a,cname,txt"},
+			args: []string{"-query-type", "a,cname,txt", "-exclude-type", "txt"},
 			expected: map[string]bool{
-				"a": true, "cname": true, "txt": true,
+				"a": true, "cname": true,
 			},
 			notExpected: map[string]bool{
-				"aaaa": true, "ns": true, "srv": true, "ptr": true,
+				"txt": true, "aaaa": true, "ns": true, "srv": true, "ptr": true,
 				"mx": true, "soa": true, "axfr": true, "caa": true, "any": true,
 			},
 		},
@@ -155,6 +179,11 @@ func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
 				"aaaa": true, "cname": true, "ns": true,
 			},
 		},
+		{
+			name:      "invalid query type flag",
+			args:      []string{"-q", "invalid_type"},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -167,7 +196,12 @@ func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
 			err := flagSet.CommandLine.Parse(tc.args)
 			require.NoError(t, err)
 
-			options.configureQueryOptions()
+			err = options.configureQueryOptions()
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
 			queryMap := map[string]bool{
 				"a": options.A, "aaaa": options.AAAA, "cname": options.CNAME,

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -137,6 +137,16 @@ func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported exclude type: invalid_type")
 	})
+
+	t.Run("all selected query types excluded returns error", func(t *testing.T) {
+		options := &Options{
+			QueryType:   goflags.StringSlice{"a"},
+			ExcludeType: goflags.StringSlice{"a"},
+		}
+		err := options.configureQueryOptions()
+		require.Error(t, err)
+		require.Equal(t, "no query types remain after exclusions", err.Error())
+	})
 }
 
 func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
@@ -182,6 +192,11 @@ func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
 		{
 			name:      "invalid query type flag",
 			args:      []string{"-q", "invalid_type"},
+			expectErr: true,
+		},
+		{
+			name:      "all selected query types excluded via flags -q a -eq a",
+			args:      []string{"-q", "a", "-eq", "a"},
 			expectErr: true,
 		},
 	}

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/projectdiscovery/goflags"
 	"github.com/stretchr/testify/require"
 )
@@ -269,5 +270,21 @@ func TestAXFR_DoesNotForceDefaultA(t *testing.T) {
 		require.False(t, runner.options.A)
 		require.Empty(t, runner.dnsx.Options.QuestionTypes)
 	})
+}
+
+func TestRaw_DefaultsToAWhenNoQuestionType(t *testing.T) {
+	options := &Options{
+		Raw:     true,
+		Retries: 5,
+	}
+	err := options.configureQueryOptions()
+	require.NoError(t, err)
+	require.False(t, options.A)
+
+	runner, err := New(options)
+	require.NoError(t, err)
+	require.NotNil(t, runner)
+	require.True(t, runner.options.A)
+	require.Contains(t, runner.dnsx.Options.QuestionTypes, dns.TypeA)
 }
 

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -234,3 +234,40 @@ func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestAXFR_DoesNotForceDefaultA(t *testing.T) {
+	t.Run("axfr alone via struct field", func(t *testing.T) {
+		options := &Options{
+			AXFR:    true,
+			Retries: 5,
+		}
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
+		require.True(t, options.AXFR)
+		require.False(t, options.A)
+
+		runner, err := New(options)
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+		require.False(t, runner.options.A)
+		require.Empty(t, runner.dnsx.Options.QuestionTypes)
+	})
+
+	t.Run("axfr alone via query type flag", func(t *testing.T) {
+		options := &Options{
+			QueryType: goflags.StringSlice{"axfr"},
+			Retries:   5,
+		}
+		err := options.configureQueryOptions()
+		require.NoError(t, err)
+		require.True(t, options.AXFR)
+		require.False(t, options.A)
+
+		runner, err := New(options)
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+		require.False(t, runner.options.A)
+		require.Empty(t, runner.dnsx.Options.QuestionTypes)
+	})
+}
+

--- a/internal/runner/options_test.go
+++ b/internal/runner/options_test.go
@@ -1,0 +1,187 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/projectdiscovery/goflags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureQueryOptions_QueryTypeAndExcludeType(t *testing.T) {
+	t.Run("query type all with exclusions", func(t *testing.T) {
+		options := &Options{
+			QueryType:   goflags.StringSlice{"all"},
+			ExcludeType: goflags.StringSlice{"ptr", "axfr", "any"},
+		}
+		options.configureQueryOptions()
+
+		require.True(t, options.A)
+		require.True(t, options.AAAA)
+		require.True(t, options.CNAME)
+		require.True(t, options.NS)
+		require.True(t, options.TXT)
+		require.True(t, options.SRV)
+		require.True(t, options.MX)
+		require.True(t, options.SOA)
+		require.True(t, options.CAA)
+
+		require.False(t, options.PTR)
+		require.False(t, options.AXFR)
+		require.False(t, options.ANY)
+	})
+
+	t.Run("specific query types", func(t *testing.T) {
+		options := &Options{
+			QueryType: goflags.StringSlice{"a", "cname", "txt"},
+		}
+		options.configureQueryOptions()
+
+		require.True(t, options.A)
+		require.True(t, options.CNAME)
+		require.True(t, options.TXT)
+
+		require.False(t, options.AAAA)
+		require.False(t, options.NS)
+		require.False(t, options.SRV)
+		require.False(t, options.PTR)
+		require.False(t, options.MX)
+		require.False(t, options.SOA)
+		require.False(t, options.AXFR)
+		require.False(t, options.CAA)
+		require.False(t, options.ANY)
+	})
+
+	t.Run("case-insensitive query types", func(t *testing.T) {
+		options := &Options{
+			QueryType: goflags.StringSlice{"A", "AAAA"},
+		}
+		options.configureQueryOptions()
+
+		require.True(t, options.A)
+		require.True(t, options.AAAA)
+
+		require.False(t, options.CNAME)
+		require.False(t, options.NS)
+		require.False(t, options.TXT)
+		require.False(t, options.SRV)
+		require.False(t, options.PTR)
+		require.False(t, options.MX)
+		require.False(t, options.SOA)
+		require.False(t, options.AXFR)
+		require.False(t, options.CAA)
+		require.False(t, options.ANY)
+	})
+
+	t.Run("legacy standalone flags compatibility", func(t *testing.T) {
+		options := &Options{
+			AAAA: true,
+			MX:   true,
+		}
+		options.configureQueryOptions()
+
+		require.True(t, options.AAAA)
+		require.True(t, options.MX)
+
+		require.False(t, options.A)
+		require.False(t, options.CNAME)
+		require.False(t, options.NS)
+		require.False(t, options.TXT)
+		require.False(t, options.SRV)
+		require.False(t, options.PTR)
+		require.False(t, options.SOA)
+		require.False(t, options.AXFR)
+		require.False(t, options.CAA)
+		require.False(t, options.ANY)
+	})
+
+	t.Run("legacy query all recon flag", func(t *testing.T) {
+		options := &Options{
+			QueryAll: true,
+		}
+		options.configureQueryOptions()
+
+		require.True(t, options.A)
+		require.True(t, options.AAAA)
+		require.True(t, options.CNAME)
+		require.True(t, options.NS)
+		require.True(t, options.TXT)
+		require.True(t, options.SRV)
+		require.True(t, options.PTR)
+		require.True(t, options.MX)
+		require.True(t, options.SOA)
+		require.True(t, options.AXFR)
+		require.True(t, options.CAA)
+		require.False(t, options.ANY)
+		require.True(t, options.Response)
+	})
+}
+
+func TestFlagSet_QueryTypeAndExcludeTypeFlags(t *testing.T) {
+	testCases := []struct {
+		name        string
+		args        []string
+		expected    map[string]bool
+		notExpected map[string]bool
+	}{
+		{
+			name: "short flags -q and -eq",
+			args: []string{"-q", "all", "-eq", "ptr,axfr,any"},
+			expected: map[string]bool{
+				"a": true, "aaaa": true, "cname": true, "ns": true,
+				"txt": true, "srv": true, "mx": true, "soa": true, "caa": true,
+			},
+			notExpected: map[string]bool{
+				"ptr": true, "axfr": true, "any": true,
+			},
+		},
+		{
+			name: "long flags -query-type and -exclude-type",
+			args: []string{"-query-type", "a,cname,txt"},
+			expected: map[string]bool{
+				"a": true, "cname": true, "txt": true,
+			},
+			notExpected: map[string]bool{
+				"aaaa": true, "ns": true, "srv": true, "ptr": true,
+				"mx": true, "soa": true, "axfr": true, "caa": true, "any": true,
+			},
+		},
+		{
+			name: "case insensitive flags",
+			args: []string{"-q", "A,AAAA", "-eq", "AAAA"},
+			expected: map[string]bool{
+				"a": true,
+			},
+			notExpected: map[string]bool{
+				"aaaa": true, "cname": true, "ns": true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			options := &Options{}
+			flagSet := goflags.NewFlagSet()
+			flagSet.StringSliceVarP(&options.QueryType, "query-type", "q", nil, "dns query type", goflags.NormalizedStringSliceOptions)
+			flagSet.StringSliceVarP(&options.ExcludeType, "exclude-type", "eq", nil, "dns query type to exclude", goflags.NormalizedStringSliceOptions)
+
+			err := flagSet.CommandLine.Parse(tc.args)
+			require.NoError(t, err)
+
+			options.configureQueryOptions()
+
+			queryMap := map[string]bool{
+				"a": options.A, "aaaa": options.AAAA, "cname": options.CNAME,
+				"ns": options.NS, "txt": options.TXT, "srv": options.SRV,
+				"ptr": options.PTR, "mx": options.MX, "soa": options.SOA,
+				"axfr": options.AXFR, "caa": options.CAA, "any": options.ANY,
+			}
+
+			for k := range tc.expected {
+				require.Truef(t, queryMap[k], "expected query type %s to be true", k)
+			}
+			for k := range tc.notExpected {
+				require.Falsef(t, queryMap[k], "expected query type %s to be false", k)
+			}
+		})
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -149,7 +149,7 @@ func New(options *Options) (*Runner, error) {
 
 	// If no option is specified or manual wildcard filtering has been requested, use query type A.
 	// Auto wildcard mode uses internal address probes and preserves the selected record types.
-	if len(questionTypes) == 0 || options.WildcardDomain != "" {
+	if (len(questionTypes) == 0 && !options.AXFR && !options.Raw) || options.WildcardDomain != "" {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -149,7 +149,7 @@ func New(options *Options) (*Runner, error) {
 
 	// If no option is specified or manual wildcard filtering has been requested, use query type A.
 	// Auto wildcard mode uses internal address probes and preserves the selected record types.
-	if (len(questionTypes) == 0 && !options.AXFR && !options.Raw) || options.WildcardDomain != "" {
+	if (len(questionTypes) == 0 && !options.AXFR) || options.WildcardDomain != "" {
 		options.A = true
 		questionTypes = append(questionTypes, dns.TypeA)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -66,6 +66,8 @@ type wildcardJob struct {
 }
 
 func New(options *Options) (*Runner, error) {
+	options.configureQueryOptions()
+
 	normalizedWildcardDomain, err := normalizeAndValidateWildcardDomain(options.WildcardDomain)
 	if err != nil {
 		return nil, errors.New("invalid wildcard domain")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -66,7 +66,9 @@ type wildcardJob struct {
 }
 
 func New(options *Options) (*Runner, error) {
-	options.configureQueryOptions()
+	if err := options.configureQueryOptions(); err != nil {
+		return nil, err
+	}
 
 	normalizedWildcardDomain, err := normalizeAndValidateWildcardDomain(options.WildcardDomain)
 	if err != nil {


### PR DESCRIPTION
### Proposed Changes
- Adds `-q, -query-type` flag to select specific DNS query types (e.g., `a, aaaa, cname, ns, txt, srv, ptr, mx, soa, axfr, caa, any, all`).
- Adds `-eq, -exclude-type` flag to exclude specific query types from a multi-query execution.
- Handles `all` expansion and subtractive exclusion dynamically while preserving backward compatibility with individual query flags.
- Includes comprehensive unit tests for flag parsing and query resolution.

Fixes #403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select one or more DNS query types using short or long query-type options.
  * Exclude specific query types with case-insensitive, whitespace-tolerant values.
  * Select all supported query types while applying specified exclusions.

* **Bug Fixes**
  * Invalid query types and exclusions now report configuration errors and stop option parsing.
  * Prevent configurations that exclude every selected query type.
  * Handle duplicate “any” exclusions consistently.
  * AXFR-only mode no longer adds an unnecessary A-record query, while raw mode still defaults to A-record queries when no type is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->