### PR TITLE
set GOTOOLCHAIN=auto in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.27-alpine AS builder
 RUN apk add --no-cache build-base
 WORKDIR /app
 COPY . /app
+ENV GOTOOLCHAIN=auto
 RUN go mod download
 RUN go build ./cmd/dnsx
 


### PR DESCRIPTION
Closes #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved the build process by enabling automatic Go toolchain selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->