### PR TITLE
fix: panic and worker hang in stream mode when no input is available

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -230,6 +230,8 @@ func New(options *Options) (*Runner, error) {
 }
 
 func (r *Runner) InputWorkerStream() {
+	defer close(r.workerchan)
+
 	var sc *bufio.Scanner
 	// attempt to load list from file
 	if fileutil.FileExists(r.options.Hosts) {
@@ -242,6 +244,9 @@ func (r *Runner) InputWorkerStream() {
 		sc = bufio.NewScanner(f)
 	} else if fileutil.HasStdin() {
 		sc = bufio.NewScanner(os.Stdin)
+	} else {
+		gologger.Error().Msgf("no input provided in stream mode, pipe hosts to stdin")
+		return
 	}
 
 	for sc.Scan() {
@@ -269,7 +274,6 @@ func (r *Runner) InputWorkerStream() {
 			r.workerchan <- item
 		}
 	}
-	close(r.workerchan)
 }
 
 func (r *Runner) InputWorker() {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/projectdiscovery/hmap/store/hybrid"
@@ -280,6 +281,56 @@ func TestRunner_InputWorkerStream(t *testing.T) {
 	}
 	expected := append(baseExpected, asnIPs...)
 	require.ElementsMatch(t, expected, got, "could not match expected output")
+}
+
+func TestRunner_InputWorkerStreamWithoutInput(t *testing.T) {
+	t.Run("no hosts file and no stdin", func(t *testing.T) {
+		// replace stdin with /dev/null to get a deterministic "no input" state
+		origStdin := os.Stdin
+		devNull, err := os.Open(os.DevNull)
+		require.NoError(t, err)
+		os.Stdin = devNull
+		t.Cleanup(func() {
+			os.Stdin = origStdin
+			_ = devNull.Close()
+		})
+
+		r := Runner{
+			options:    &Options{Stream: true},
+			workerchan: make(chan string),
+		}
+		require.NotPanics(t, r.InputWorkerStream)
+		requireWorkerChanClosed(t, r.workerchan)
+	})
+
+	t.Run("unreadable hosts file", func(t *testing.T) {
+		f, err := os.CreateTemp("", "dnsx-stream-*")
+		require.NoError(t, err)
+		name := f.Name()
+		require.NoError(t, f.Close())
+		require.NoError(t, os.Chmod(name, 0o000))
+		t.Cleanup(func() {
+			_ = os.Chmod(name, 0o644)
+			_ = os.Remove(name)
+		})
+
+		r := Runner{
+			options:    &Options{Stream: true, Hosts: name},
+			workerchan: make(chan string),
+		}
+		require.NotPanics(t, r.InputWorkerStream)
+		requireWorkerChanClosed(t, r.workerchan)
+	})
+}
+
+func requireWorkerChanClosed(t *testing.T, workerchan chan string) {
+	t.Helper()
+	select {
+	case _, ok := <-workerchan:
+		require.False(t, ok, "workerchan should be closed")
+	case <-time.After(10 * time.Second):
+		t.Fatal("input worker returned without closing workerchan")
+	}
 }
 
 func TestNewRejectsAutoWildcardAndWildcardDomainTogether(t *testing.T) {


### PR DESCRIPTION
Running `dnsx -stream` without piped stdin (e.g. interactively, or with stdin on `/dev/null`) panics with a nil pointer dereference in `InputWorkerStream`, since neither the `-l` file nor stdin is present and the scanner is left nil:

```
$ dnsx -stream < /dev/null
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x79 pc=0x6486ba]

goroutine 27 [running]:
bufio.(*Scanner).Scan(0x0?)
        src/bufio/scan.go:140 +0x1a
github.com/projectdiscovery/dnsx/internal/runner.(*Runner).InputWorkerStream(...)
        internal/runner/runner.go:247 +0x258
```

The same function also returns early on hosts-file open errors without closing `workerchan`, leaving the resolve workers blocked forever in `for domain := range r.workerchan`.

This closes the channel via `defer` so every exit path unblocks the workers, and reports the missing input instead of panicking. Regression tests cover both the no-input and unreadable-hosts-file paths (`TestRunner_InputWorkerStreamWithoutInput`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stream-mode handling when no standard input or host-file input is available.
  - The scanner now exits safely with an error instead of risking a panic or stalled processing.
  - Worker processing is reliably closed after stream completion or early termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->