### PR TITLE
test(options): add PTR reverse lookup options validation specs

### DIFF
--- a/libs/dnsx/day3_w07_ptr_test.go
+++ b/libs/dnsx/day3_w07_ptr_test.go
@@ -1,0 +1,16 @@
+package dnsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsPTRLookupValidation(t *testing.T) {
+	opts := DefaultOptions
+	opts.PTR = true
+	opts.Domains = []string{"192.0.2.1", "198.51.100.1"}
+
+	assert.True(t, opts.PTR)
+	assert.Equal(t, 2, len(opts.Domains))
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `Options` struct configuring PTR reverse DNS lookup domain targets.\n\n### Testing\n- Tested with testify/assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify PTR lookup configuration, including enabling resolution and configuring multiple domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->