### PR TITLE
test(options): add custom nameserver port override validation specs

### DIFF
--- a/libs/dnsx/day3_w10_nsport_test.go
+++ b/libs/dnsx/day3_w10_nsport_test.go
@@ -1,0 +1,16 @@
+package dnsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsCustomNameserverPortValidation(t *testing.T) {
+	opts := DefaultOptions
+	opts.BaseResolvers = []string{"127.0.0.1:8053", "1.1.1.1:53"}
+	opts.Domains = []string{"example.com"}
+
+	assert.Equal(t, 2, len(opts.BaseResolvers))
+	assert.Contains(t, opts.BaseResolvers, "127.0.0.1:8053")
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `Options` struct configuring custom port nameserver resolvers.\n\n### Testing\n- Tested with testify/assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify that custom-port nameservers are accepted and preserved alongside standard-port nameservers during DNS configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->