### PR TITLE
test(options): add DNS query timeout duration options validation specs

### DIFF
--- a/libs/dnsx/day3_w14_timeout_test.go
+++ b/libs/dnsx/day3_w14_timeout_test.go
@@ -1,0 +1,17 @@
+package dnsx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsQueryTimeoutValidation(t *testing.T) {
+	opts := DefaultOptions
+	opts.Timeout = 10 * time.Second
+	opts.Domains = []string{"timeout.example.com"}
+
+	assert.Equal(t, 10*time.Second, opts.Timeout)
+	assert.Equal(t, 1, len(opts.Domains))
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `Options` struct configuring per-query DNS socket timeout durations.\n\n### Testing\n- Tested with testify/assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying that DNS query timeout and domain options retain their configured values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->