### PR TITLE
test(options): add DNS lookup retry limit options validation specs

### DIFF
--- a/libs/dnsx/day3_w18_backoff_test.go
+++ b/libs/dnsx/day3_w18_backoff_test.go
@@ -1,0 +1,16 @@
+package dnsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsRetryBackoffValidation(t *testing.T) {
+	opts := DefaultOptions
+	opts.MaxRetries = 5
+	opts.Domains = []string{"retry.example.com"}
+
+	assert.Equal(t, 5, opts.MaxRetries)
+	assert.Equal(t, 1, len(opts.Domains))
+}


### PR DESCRIPTION
### Summary\n- Adds test coverage for `Options` struct configuring lookup retry limits.\n\n### Testing\n- Tested with testify/assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying that DNS retry settings accept a configured maximum retry count and a single domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->