### PR TITLE
test(options): add multiple RCODE filter validation specs

### DIFF
--- a/libs/dnsx/day3_w22_rcode_test.go
+++ b/libs/dnsx/day3_w22_rcode_test.go
@@ -1,0 +1,16 @@
+package dnsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsMultipleRCodeFilterValidation(t *testing.T) {
+	opts := DefaultOptions
+	opts.ResponseCode = "NOERROR,SERVFAIL,REFUSED"
+	opts.Domains = []string{"filter.example.com"}
+
+	assert.Equal(t, "NOERROR,SERVFAIL,REFUSED", opts.ResponseCode)
+	assert.Equal(t, 1, len(opts.Domains))
+}


### PR DESCRIPTION
### Summary
- Adds test coverage for Options struct configuring comma-delimited DNS RCODE filters.

### Testing
- Tested with testify/assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify that multiple DNS response-code filters are preserved correctly.
  - Confirmed domain filter values remain intact when multiple response codes are specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->